### PR TITLE
added dummy interface for 17.4R1.16

### DIFF
--- a/config-engine-lite/Dockerfile
+++ b/config-engine-lite/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update -qy \
     python-pip \
     zlib1g-dev \
  && rm -rf /var/lib/apt/lists/* \
+ && pip install --upgrade pip \
  && pip install napalm
 
 ADD configengine /

--- a/vmx/docker/launch.py
+++ b/vmx/docker/launch.py
@@ -191,7 +191,7 @@ class VMX_vfpc(vrnetlab.VM):
         res.extend(["-netdev",
                     "tap,ifname=vfpc-int,id=vfpc-int,script=no,downscript=no"])
 
-        if self.version in ('15.1F6.9', '16.1R2.11', '17.2R1.13'):
+        if self.version in ('15.1F6.9', '16.1R2.11', '17.2R1.13', '17.4R1.16'):
             # dummy interface for some vMX versions - not sure why vFPC wants
             # it but without it we get a misalignment
             res.extend(["-device", "virtio-net-pci,netdev=dummy,mac=%s" %


### PR DESCRIPTION
Tested vr-xon connection for 17.4R1.16 image by modifying the self.version and it works perfectly now.