### PR TITLE
Make image matching glob less greedy, fixes #273

### DIFF
--- a/veos/Makefile
+++ b/veos/Makefile
@@ -1,7 +1,7 @@
 VENDOR=Arista
 NAME=vEOS
 IMAGE_FORMAT=vmdk
-IMAGE_GLOB=*.vmdk
+IMAGE_GLOB=vEOS-lab*.vmdk
 
 # match versions like:
 # vEOS-lab-4.16.6M.vmdk


### PR DESCRIPTION
Ensures we don't try to build with vEOS64 images, which is non-functional