### PR TITLE
Add veos support to topomachine

### DIFF
--- a/topology-machine/topomachine
+++ b/topology-machine/topomachine
@@ -22,7 +22,7 @@ class VrTopo:
         for r, val in self.routers.items():
             if 'type' not in val:
                 raise ValueError("'type' is not defined for router %s" % r)
-            if val['type'] not in ('dummy', 'xcon', 'bgp', 'xrv', 'xrv9k', 'vmx', 'sros', 'csr', 'vqfx', 'vrp'):
+            if val['type'] not in ('dummy', 'xcon', 'bgp', 'xrv', 'xrv9k', 'vmx', 'sros', 'csr', 'vqfx', 'vrp', 'veos'):
                 raise ValueError("Unknown type %s for router %s" % (val['type'], r))
 
         # expand p2p links
@@ -136,6 +136,8 @@ class VrTopo:
             return "xe-0/0/%d" % (interface-1)
         elif r['type'] == 'vrp':
             return "GigabitEthernet4/0/%d" % (interface)
+        elif r['type'] == 'veos':
+            return "Ethernet%d" % (interface)
 
         return None
 


### PR DESCRIPTION
This adds veos support for topomachine generation.
This change needs the change in #256 to not be off by one on every interface.