### PR TITLE
Add install to xrv9k

### DIFF
--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -363,6 +363,19 @@ class VR:
                 else:
                     self.update_health(1, "starting")
 
+class VR_Installer:
+    def __init__(self):
+        self.logger = logging.getLogger()
+        self.vm = None
+
+    def install(self):
+        vm =  self.vm
+        while not vm.running:
+            self.logger.trace("%s working", self.__class__.__name__)
+            vm.work()
+        self.logger.debug("%s running, shutting down", self.__class__.__name__)
+        vm.stop()
+        self.logger.info("Installation complete")
 
 class QemuBroken(Exception):
     """ Our Qemu instance is somehow broken

--- a/xrv9k/Makefile
+++ b/xrv9k/Makefile
@@ -11,3 +11,4 @@ VERSION=$(shell echo $(IMAGE) | sed -e 's/.\+[^0-9]\([0-9]\.[0-9]\.[0-9]\(\.[0-9
 
 -include ../makefile-sanity.include
 -include ../makefile.include
+-include ../makefile-install.include


### PR DESCRIPTION
This MR adds a new option `--install` for `xrv9k`.

When the vanilla image from Cisco starts up, it takes a long time to install various packages. This happens every time a VR is started. With the `--install` option and Makefile changes, the packages are pre-installed during the docker image build, reducing the start time when this image is used.

The images created with the `--install` option starts up in half of the time compared with previous images.
However the newly created image is about 3 times larger than previous one.