### PR TITLE
Add gRPC support for vMX

### DIFF
--- a/vmx/docker/Dockerfile
+++ b/vmx/docker/Dockerfile
@@ -17,7 +17,7 @@ COPY vmx /vmx
 COPY *.py /
 COPY juniper.conf /
 
-EXPOSE 22 161/udp 830 5000 10000-10099
+EXPOSE 22 161/udp 830 5000 57400 10000-10099
 # mgmt and console ports for re1
 EXPOSE 1022 1161/udp 1830 5001
 HEALTHCHECK CMD ["/healthcheck.py"]

--- a/vmx/docker/juniper.conf
+++ b/vmx/docker/juniper.conf
@@ -44,6 +44,15 @@ system {
     }
     services {
         ssh;
+        extension-service {
+            request-response {
+                grpc {
+                    clear-text {
+                        port 57400;
+                    }
+                }
+            }
+        }
         netconf {
             ssh;
         }

--- a/vmx/docker/launch.py
+++ b/vmx/docker/launch.py
@@ -30,7 +30,8 @@ def trace(self, message, *args, **kws):
         self._log(TRACE_LEVEL_NUM, message, args, **kws)
 logging.Logger.trace = trace
 
-
+#append port for gRPCs
+vrnetlab.HOST_FWDS.append(('tcp', 57400, 57400))
 
 class VMX_vcp(vrnetlab.VM):
     def __init__(self, username, password, image, version, dual_re=False, re_instance=0, install_mode=False):


### PR DESCRIPTION
This commit adds support for gRPC and GNMI in Juniper vMX routers.

Includes:
  - Dockerfile: expose the container's 57400 TCP port

  - juniper.conf: add configuration knob to enable JUNOS clear-text and unauthenticated gRPC interface

  - launch.py: `vrnetlab.HOST_FWDS` defines the list of ports to be forwarded. Edit launch.py to append the TCP/57400:57400 forwarding
  
  Port 57400 is used for uniformity with [78da58e](https://github.com/vrnetlab/vrnetlab/pull/285/commits/78da58e7c513ee85956154cea54991fd25d563e3) as there is no officially assigned port or a default for JunOS devices.
  
  Tested for JunOS 20.4R3.8 for vMX