### PR TITLE
refactor: replace oui for base mac generation

### DIFF
--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -25,10 +25,12 @@ HOST_FWDS = [
 ]
 
 def gen_mac(last_octet=None):
-    """ Generate a random MAC address that is in the qemu OUI space and that
+    """ Generate a random MAC address that is in unused OUI space and that
         has the given last octet.
     """
-    return "52:54:00:%02x:%02x:%02x" % (
+    return "0C:%02x:%02x:%02x:%02x:%02x" % (
+            random.randint(0x00, 0xff),
+            random.randint(0x00, 0xff),
             random.randint(0x00, 0xff),
             random.randint(0x00, 0xff),
             last_octet


### PR DESCRIPTION
Currently, `gen_mac()` generates a mac address in the qemu OUI space (`52:54`) -- a very sensible and responsible decision. 

However, mac addresses starting with 52 cause a crash of the MLAG process in Arista vEOS, as it's unable to generate a virtual mac address. The same issue was experienced in the GNS3 project when they too moved to the qemu OUI space: https://github.com/GNS3/gns3-gui/issues/2475

I propose an equivalent solution: moving to a `0C:` prefixed mac address. 