### PR TITLE
Improve VRP

### DIFF
--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -327,6 +327,14 @@ class VM:
         wait_spins = 0
         # 10s * 90 = 900s = 15min timeout
         while wait_spins < spins:
+            # On some devices (Huawei VRP), the command to disable paging
+            # only has a temporary effect?!
+            # To make sure we're not getting paged output, send the no_paging_command
+            # always, if the attribute exists on the extended VM class.
+            try:
+                self.wait_write(self.no_paging_command, wait=None)
+            except AttributeError:
+                pass
             self.wait_write(show_cmd, wait=None)
             _, match, data = self.tn.expect([expect.encode('UTF-8')], timeout=10)
             self.logger.trace(data.decode('UTF-8'))

--- a/vrp/docker/launch.py
+++ b/vrp/docker/launch.py
@@ -115,6 +115,7 @@ class simulator_VM(vrnetlab.VM):
 
         self.wait_write(cmd="system-view", wait=">")
         self.wait_write(cmd="sysname HUAWEI", wait="]")
+        self.wait_write(cmd="ssh server key-exchange dh_group14_sha1", wait="]")
         self.wait_write(cmd="interface GigabitEthernet 0/0/0", wait="]")
         self.wait_write(cmd="ip address 10.0.0.15 24", wait="]")
         self.wait_write(cmd="commit", wait="]")

--- a/vrp/docker/launch.py
+++ b/vrp/docker/launch.py
@@ -112,6 +112,12 @@ class simulator_VM(vrnetlab.VM):
         self.wait_config("display current-configuration interface GigabitEthernet", 'GigabitEthernet4/0/1')
         self.wait_config("display current-configuration interface GigabitEthernet", 'GigabitEthernet4/0/4')
         self.wait_config("display current-configuration interface GigabitEthernet", 'GigabitEthernet4/0/14')
+        # The first response might be the log message like
+        # 12/active/linkDown/Major/occurredTime:2019-11-11 23:49:03/-/-/alarmID:0x08520003/VS=Admin-VS-CID=0x807a0404:The interface status changes. (ifName=GigabitEthernet4/0/14, AdminStatus=UP, OperStatus=UP, Reason=Interface physical link is up, mainIfname=GigabitEthernet4/0/14
+        # So wait three more times to make sure we get the correct response
+        self.wait_config("display current-configuration interface GigabitEthernet", 'GigabitEthernet4/0/14')
+        self.wait_config("display current-configuration interface GigabitEthernet", 'GigabitEthernet4/0/14')
+        self.wait_config("display current-configuration interface GigabitEthernet", 'GigabitEthernet4/0/14')
         self.logger.info("applying bootstrap configuration")
         self.wait_write(cmd="", wait=None)
         self.wait_write(cmd="", wait=None)

--- a/vrp/docker/launch.py
+++ b/vrp/docker/launch.py
@@ -4,10 +4,8 @@ import datetime
 import logging
 import re
 import signal
-import subprocess
 import sys
 import time
-import math
 import os
 import vrnetlab
 
@@ -111,7 +109,12 @@ class simulator_VM(vrnetlab.VM):
     def bootstrap_config(self):
         """ Do the actual bootstrap config
         """
+        self.wait_config("display current-configuration interface GigabitEthernet", 'GigabitEthernet4/0/1')
+        self.wait_config("display current-configuration interface GigabitEthernet", 'GigabitEthernet4/0/4')
+        self.wait_config("display current-configuration interface GigabitEthernet", 'GigabitEthernet4/0/14')
         self.logger.info("applying bootstrap configuration")
+        self.wait_write(cmd="", wait=None)
+        self.wait_write(cmd="", wait=None)
 
         self.wait_write(cmd="system-view", wait=">")
         self.wait_write(cmd="sysname HUAWEI", wait="]")
@@ -140,12 +143,11 @@ class simulator_VM(vrnetlab.VM):
         self.wait_write(cmd="local-user %s user-group manage-ug" % self.username, wait="]")
         self.wait_write(cmd="commit", wait="]")
 
-
 class simulator(vrnetlab.VR):
 
     def __init__(self, username, password):
-         super(simulator, self).__init__(username, password)
-         self.vms = [simulator_VM(username, password)]
+        super(simulator, self).__init__(username, password)
+        self.vms = [simulator_VM(username, password)]
 
 
 if __name__ == '__main__':

--- a/vrp/docker/launch.py
+++ b/vrp/docker/launch.py
@@ -28,6 +28,8 @@ def trace(self, message, *args, **kws):
 logging.Logger.trace = trace
 
 class simulator_VM(vrnetlab.VM):
+    no_paging_command = 'screen-length 0 temporary'
+
     def __init__(self, username, password):
         for e in os.listdir("/"):
             if re.search(".qcow2$", e):
@@ -109,15 +111,18 @@ class simulator_VM(vrnetlab.VM):
     def bootstrap_config(self):
         """ Do the actual bootstrap config
         """
-        self.wait_config("display current-configuration interface GigabitEthernet", 'GigabitEthernet4/0/1')
-        self.wait_config("display current-configuration interface GigabitEthernet", 'GigabitEthernet4/0/4')
-        self.wait_config("display current-configuration interface GigabitEthernet", 'GigabitEthernet4/0/14')
+        # Wait for GigabitEthernet4/0/X interfaces to appear in running config
+        # NOTE: do not use 'display current-configuration interface GigabitEtherhet 4/0/X'
+        # to check. The output differs from 'display current-configuration'!
+        self.wait_config("display current-configuration", 'interface GigabitEthernet4/0/1')
+        self.wait_config("display current-configuration", 'interface GigabitEthernet4/0/4')
+        self.wait_config("display current-configuration", 'interface GigabitEthernet4/0/14')
         # The first response might be the log message like
         # 12/active/linkDown/Major/occurredTime:2019-11-11 23:49:03/-/-/alarmID:0x08520003/VS=Admin-VS-CID=0x807a0404:The interface status changes. (ifName=GigabitEthernet4/0/14, AdminStatus=UP, OperStatus=UP, Reason=Interface physical link is up, mainIfname=GigabitEthernet4/0/14
         # So wait three more times to make sure we get the correct response
-        self.wait_config("display current-configuration interface GigabitEthernet", 'GigabitEthernet4/0/14')
-        self.wait_config("display current-configuration interface GigabitEthernet", 'GigabitEthernet4/0/14')
-        self.wait_config("display current-configuration interface GigabitEthernet", 'GigabitEthernet4/0/14')
+        self.wait_config("display current-configuration", 'interface GigabitEthernet4/0/14')
+        self.wait_config("display current-configuration", 'interface GigabitEthernet4/0/14')
+        self.wait_config("display current-configuration", 'interface GigabitEthernet4/0/14')
         self.logger.info("applying bootstrap configuration")
         self.wait_write(cmd="", wait=None)
         self.wait_write(cmd="", wait=None)

--- a/vrp/docker/launch.py
+++ b/vrp/docker/launch.py
@@ -116,7 +116,7 @@ class simulator_VM(vrnetlab.VM):
         self.wait_write(cmd="", wait=None)
         self.wait_write(cmd="", wait=None)
 
-        self.wait_write(cmd="system-view", wait=">")
+        self.wait_write(cmd="system-view", wait=None)
         self.wait_write(cmd="sysname HUAWEI", wait="]")
         self.wait_write(cmd="ssh server key-exchange dh_group14_sha1", wait="]")
         self.wait_write(cmd="interface GigabitEthernet 0/0/0", wait="]")

--- a/xrv9k/docker/launch.py
+++ b/xrv9k/docker/launch.py
@@ -165,11 +165,11 @@ class XRV_vm(vrnetlab.VM):
         self.wait_write("")
 
         # wait for Gi0/0/0/0 in config
-        if not self._wait_config("show interfaces description", "Gi0/0/0/0"):
+        if not self.wait_config("show interfaces description", "Gi0/0/0/0"):
             return False
 
         # wait for call-home in config
-        if not self._wait_config("show running-config call-home", "service active"):
+        if not self.wait_config("show running-config call-home", "service active"):
             return False
 
         self.wait_write("configure")
@@ -193,23 +193,6 @@ class XRV_vm(vrnetlab.VM):
 
         return True
 
-    def _wait_config(self, show_cmd, expect):
-        """ Some configuration takes some time to "show up".
-            To make sure the device is really ready, wait here.
-        """
-        self.logger.debug('waiting for {} to appear in {}'.format(expect, show_cmd))
-        wait_spins = 0
-        # 10s * 90 = 900s = 15min timeout
-        while wait_spins < 90:
-            self.wait_write(show_cmd, wait=None)
-            _, match, data = self.tn.expect([expect.encode('UTF-8')], timeout=10)
-            self.logger.trace(data.decode('UTF-8'))
-            if match:
-                self.logger.debug('a wild {} has appeared!'.format(expect))
-                return True
-            wait_spins += 1
-        self.logger.error('{} not found in {}'.format(expect, show_cmd))
-        return False
 
 class XRV_Installer(vrnetlab.VR_Installer):
     """ XRV installer
@@ -223,6 +206,7 @@ class XRV_Installer(vrnetlab.VR_Installer):
     def __init__(self, username, password, ram, nics):
         super().__init__()
         self.vm = XRV_vm(username, password, ram, nics, install_mode=True)
+
 
 class XRV(vrnetlab.VR):
     def __init__(self, username, password, ram, nics):


### PR DESCRIPTION
The Huawei VRP devices boot up and present the login prompt before all components are running. If we try to configure the device immediately after the vrnetlab container starts up and reports healthy, some interfaces may still be missing! This MR adds interface detection to bootstrap script and will prevent the container from becoming healthy until the expected GigabitEthernet interfaces show up.