### PR TITLE
Fix config-engine-lite container image

### DIFF
--- a/config-engine-lite/Dockerfile
+++ b/config-engine-lite/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:jammy
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -15,14 +15,13 @@ RUN apt-get update -qy \
     libxml2-dev \
     libxslt1-dev \
     libyaml-dev \
-    python-dev \
-    python-dev \
-    python-ipy \
-    python-lxml \
-    python-pip \
+    python3-dev \
+    python3-ipy \
+    python3-lxml \
+    python3-pip \
     zlib1g-dev \
  && rm -rf /var/lib/apt/lists/* \
- && pip install napalm
+ && pip3 install napalm
 
 ADD configengine /
 

--- a/config-engine-lite/configengine
+++ b/config-engine-lite/configengine
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import json
 import sys


### PR DESCRIPTION
As described in #230 it is not possible to build the container image for `config-engine-lite`. Python 2.7 is a dead end and Xenial only includes Python 3.5. Instead of trying to figure out which version of pip, napalm and other dependencies still works with these old Python versions I tried updating the base image to Jammy and then use Python 3.10. It works, at least the simple test for applying the template listed in the readme!