### PR TITLE
Use debian bullseye

### DIFF
--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -52,7 +52,8 @@ def run_command(cmd, cwd=None, background=False):
 
 class VM:
     def __str__(self):
-        return self.__class__.__name__
+        # TODO: use this in the logger?!
+        return f"{self.__class__.__name__}[{self.num}]"
 
 
     def __init__(self, username, password, disk_image=None, num=0, ram=4096):
@@ -92,7 +93,7 @@ class VM:
 
 
     def start(self):
-        self.logger.info("Starting %s" % self.__class__.__name__)
+        self.logger.info("Starting %s" % self)
 
         cmd = list(self.qemu_args)
 
@@ -369,7 +370,7 @@ class VR:
     def start(self):
         """ Start the virtual router
         """
-        self.logger.debug("Starting vrnetlab %s", self.__class__.__name__)
+        self.logger.debug("Starting vrnetlab %s", self)
         self.logger.debug("VMs: %s", self.vms)
         self.start_socat()
 
@@ -398,9 +399,9 @@ class VR_Installer:
     def install(self):
         vm =  self.vm
         while not vm.running:
-            self.logger.trace("%s working", self.__class__.__name__)
+            self.logger.trace("%s working", self)
             vm.work()
-        self.logger.debug("%s running, shutting down", self.__class__.__name__)
+        self.logger.debug("%s running, shutting down", self)
         vm.stop()
         self.logger.info("Installation complete")
 

--- a/csr/docker/Dockerfile
+++ b/csr/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/nxos/docker/Dockerfile
+++ b/nxos/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/nxos9kv/docker/Dockerfile
+++ b/nxos9kv/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/openwrt/docker/Dockerfile
+++ b/openwrt/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/routeros/docker/Dockerfile
+++ b/routeros/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/sros/docker/Dockerfile
+++ b/sros/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/topology-machine/Dockerfile
+++ b/topology-machine/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/veos/docker/Dockerfile
+++ b/veos/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/vmx/docker/Dockerfile
+++ b/vmx/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/vmx/docker/launch.py
+++ b/vmx/docker/launch.py
@@ -161,7 +161,7 @@ class VMX_vcp(vrnetlab.VM):
         self.wait_write("configure", '>', 10)
         self.wait_write("load merge /mnt/extra-config.conf")
         self.wait_write("commit")
-        self.wait_write("exit")
+        self.wait_write("exit", "#")
 
 
     def wait_write(self, cmd, wait='#', timeout=None):

--- a/vqfx/docker/Dockerfile
+++ b/vqfx/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/vr-xcon/Dockerfile
+++ b/vr-xcon/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/vrp/docker/Dockerfile
+++ b/vrp/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 RUN apt-get update -qy \

--- a/vsr1000/docker/Dockerfile
+++ b/vsr1000/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/xrv/docker/Dockerfile
+++ b/xrv/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/xrv9k/docker/Dockerfile
+++ b/xrv9k/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
The `stretch` release was removed from the package repositories (or rather all packages were removed from the `stretch` repos). Anyway, `stretch` was long in the tooth when #201 was first opened and now we have no choice but to upgrade to fix image builds. 

Because QEMU & friends are also upgraded this branch now includes a fix for overlay disk image creation per VM instance. This is no longer allowed (a write lock prevents it) to share a disk image across multiple guests. vrnetlab did exactly the same when running a network device in distributed mode - a VM for control plane and one or more VMs for the forwarding plane. Why that worked at all is puzzling, but it cannot be done using new QEMU without an extra NBD layer anyway. 

This project (on github) does not include CI, but we have a local mirror that builds images for almost all platforms and also does a smoke test to check container health. It looks promising.

Closes #201 