### PR TITLE
Upgrade vrnetlab/ci-builder image to Ubuntu Jammy

### DIFF
--- a/ci-builder-image/Dockerfile
+++ b/ci-builder-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:yakkety
+FROM debian:bullseye
 
 RUN apt-get update \
  && apt-get install -y \


### PR DESCRIPTION
Ubuntu Yakkety package repos are gone, if we want to rebuild the CI image we must upgrade Ubuntu ...

Below is the difference in installed package versions. The biggest risk is Docker IMHO, but we don't do anything super advanced with it that would break with the new version?

```
root@41c1874359a6:/# cat /etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=16.10
DISTRIB_CODENAME=yakkety
DISTRIB_DESCRIPTION="Ubuntu 16.10"
root@41c1874359a6:/# git --version
git version 2.9.3
root@41c1874359a6:/# git-lfs version
git-lfs/2.3.4 (GitHub; linux amd64; go 1.8.1)
root@41c1874359a6:/# docker --version
Docker version 1.12.6, build 78d1802
root@41c1874359a6:/# curl --version
curl 7.50.1 (x86_64-pc-linux-gnu) libcurl/7.50.1 GnuTLS/3.5.3 zlib/1.2.8 libidn/1.33 librtmp/2.3
Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps pop3 pop3s rtmp rtsp smb smbs smtp smtps telnet tftp
Features: AsynchDNS IDN IPv6 Largefile GSS-API Kerberos SPNEGO NTLM NTLM_WB SSL libz TLS-SRP UnixSockets
root@41c1874359a6:/# make --version
GNU Make 4.1
Built for x86_64-pc-linux-gnu
Copyright (C) 1988-2014 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

root@ab845513adf1:/# cat /etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=22.04
DISTRIB_CODENAME=jammy
DISTRIB_DESCRIPTION="Ubuntu 22.04.2 LTS"
root@ab845513adf1:/# git --version
git version 2.34.1
root@ab845513adf1:/# git-lfs version
git-lfs/3.3.0 (GitHub; linux amd64; go 1.19.3)
root@ab845513adf1:/# docker --version
Docker version 20.10.21, build 20.10.21-0ubuntu1~22.04.2
root@ab845513adf1:/# curl --version
curl 7.81.0 (x86_64-pc-linux-gnu) libcurl/7.81.0 OpenSSL/3.0.2 zlib/1.2.11 brotli/1.0.9 zstd/1.4.8 libidn2/2.3.2 libpsl/0.21.0 (+libidn2/2.3.2) libssh/0.9.6/openssl/zlib nghttp2/1.43.0 librtmp/2.3 OpenLDAP/2.5.14
Release-Date: 2022-01-05
Protocols: dict file ftp ftps gopher gophers http https imap imaps ldap ldaps mqtt pop3 pop3s rtmp rtsp scp sftp smb smbs smtp smtps telnet tftp
Features: alt-svc AsynchDNS brotli GSS-API HSTS HTTP2 HTTPS-proxy IDN IPv6 Kerberos Largefile libz NTLM NTLM_WB PSL SPNEGO SSL TLS-SRP UnixSockets zstd
root@ab845513adf1:/# make --version
GNU Make 4.3
Built for x86_64-pc-linux-gnu
Copyright (C) 1988-2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```