### PR TITLE
Bundle license with vmx

### DIFF
--- a/makefile-install.include
+++ b/makefile-install.include
@@ -28,7 +28,7 @@
 # contains the committed changes from the install phase of the previous build.
 # Include this makefile to have your image automatically do that dance.
 
-docker-pre-build:
+docker-pre-build::
 	-cat cidfile | xargs --no-run-if-empty docker rm -f
 	-rm cidfile
 	-docker tag $(REGISTRY)vr-$(VR_NAME):$(VERSION) $(REGISTRY)vr-$(VR_NAME):$(VERSION)-previous-build

--- a/makefile.include
+++ b/makefile.include
@@ -15,7 +15,7 @@ endif
 docker-clean-build:
 	-rm -f docker/*.qcow2* docker/*.tgz* docker/*.vmdk* docker/*.iso
 
-docker-pre-build: ;
+docker-pre-build:: ;
 
 docker-build-image-copy:
 	cp $(IMAGE)* docker/

--- a/nxos9kv/Makefile
+++ b/nxos9kv/Makefile
@@ -10,5 +10,5 @@ VERSION=$(shell echo $(IMAGE) | sed -e 's/.\+[^0-9]\([0-9]\.[0-9]\.[0-9].*\)\.qc
 -include ../makefile-sanity.include
 -include ../makefile.include
 
-docker-pre-build:
+docker-pre-build::
 	cp OVMF-pure-efi.fd nxos_config.txt docker

--- a/veos/Makefile
+++ b/veos/Makefile
@@ -14,5 +14,5 @@ VERSION=$(shell echo $(IMAGE) | sed -e 's/.*-\([0-9]\.\([0-9]\+\.\)\{1,2\}[0-9]\
 -include ../makefile-sanity.include
 -include ../makefile.include
 
-docker-pre-build:
+docker-pre-build::
 	cp *.iso docker/

--- a/vmx/Makefile
+++ b/vmx/Makefile
@@ -15,10 +15,17 @@ IMAGE_GLOB=*.tgz
 VERSION=$(shell echo $(IMAGE) | sed -e 's/.\+[^0-9]\([0-9][0-9]\.[0-9][A-Z][0-9]\+\(\.[0-9]\+\|-[SD][0-9]\+\(\.[0-9]\+\)\?\)\)[^0-9].*$$/\1/')
 
 EXTRA_INSTALL_ARGS=--dual-re
+LICENSE?=$(notdir $(wildcard docker/*.lic))
+ifneq ($(LICENSE),)
+EXTRA_INSTALL_ARGS+=--license-file $(LICENSE)
+endif
 
 -include ../makefile-sanity.include
 -include ../makefile.include
 -include ../makefile-install.include
+
+docker-pre-build:
+	-cp *.lic docker/
 
 docker-build-image-copy:
 	./vmx-extract.sh $(IMAGE)

--- a/vmx/Makefile
+++ b/vmx/Makefile
@@ -24,7 +24,7 @@ endif
 -include ../makefile.include
 -include ../makefile-install.include
 
-docker-pre-build:
+docker-pre-build::
 	-cp *.lic docker/
 
 docker-build-image-copy:

--- a/vmx/README.md
+++ b/vmx/README.md
@@ -60,6 +60,14 @@ It is NOT working with the following images:
 
  * vmx-15.1F3.11.tgz  MD5:978fc8c0db05179564d0680040db8196
 
+### License
+
+You can bundle one or more license files with the vMX image to unlock the full
+throughput (bandwidth) capability of the device or additional features. If you
+have a valid license file, like JUNOS12345678.lic, just place it next to the
+image. The license file will be copied to the drive containing bootstrap config
+and will be automatically applied when the device boots up.
+
 Usage
 -----
 The container must be `--privileged` to start KVM.

--- a/vmx/docker/Dockerfile
+++ b/vmx/docker/Dockerfile
@@ -18,6 +18,7 @@ ENV VERSION=${VERSION}
 COPY vmx /vmx
 COPY *.py /
 COPY juniper.conf /
+COPY *.lic /
 
 EXPOSE 22 161/udp 830 5000 57400 10000-10099
 # mgmt and console ports for re1

--- a/vmx/docker/launch.py
+++ b/vmx/docker/launch.py
@@ -340,7 +340,8 @@ class VMX_installer(VMX):
         self.logger.debug("All %d VCPs running" % len(self.vms))
 
         def waitable_pipes():
-            return [vcp.p.stdout for vcp in self.vms if vcp.running] + [vcp.p.stderr for vcp in self.vms if vcp.running]
+            return [vcp.p.stdout for vcp in self.vms if vcp.running and not vcp.p.stdout.closed] + \
+                [vcp.p.stderr for vcp in self.vms if vcp.running and not vcp.p.stderr.closed]
         # wait for system to shut down cleanly
         while waitable_pipes():
             read_pipes, _, _ = select.select(waitable_pipes(), [],  [])

--- a/vqfx/Makefile
+++ b/vqfx/Makefile
@@ -12,7 +12,7 @@ VERSION=$(shell echo $(IMAGE) | sed -e 's/^vqfx10k-re-\([0-9][0-9]\.[0-9][A-Z][0
 
 # vqfx10k-pfe-20160609-2.vmdk
 # TODO: we should make sure we only copy one PFE image (the latest?), in case there are many
-docker-pre-build:
+docker-pre-build::
 	cp vqfx10k-pfe*.vmdk docker/
 
 # TODO: upstream the rest of the fixes to make it work


### PR DESCRIPTION
The vMX image builder now supports bundling a license file with the installed image - simply place the `JUNOS12345789.lic` file in the `vmx/docker` directory.

Note: the license file is not only copied to the bootstrap drive, but also remains in the root folder of the docker image. To avoid that we could pass the license to the installer as an env var, but is it worth it?