### PR TITLE
IOS XE domain-name

### DIFF
--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -356,6 +356,19 @@ class VM:
         self.logger.error('{} not found in {}'.format(expect, show_cmd))
         return False
 
+    @property
+    def version(self):
+        """Read version number from VERSION environment variable
+
+        The VERSION environment variable is set at build time using the value
+        from the makefile. If the environment variable is not defined please add
+        the variables in the Dockerfile (see csr)"""
+        version = os.environ.get("VERSION")
+        if version is not None:
+            return version
+        raise ValueError("The VERSION environment variable is not set")
+
+
 class VR:
     def __init__(self, username, password):
         self.logger = logging.getLogger()

--- a/csr/Makefile
+++ b/csr/Makefile
@@ -6,7 +6,7 @@ IMAGE_GLOB=*.qcow2
 # match versions like:
 # csr1000v-universalk9.16.03.01a.qcow2
 # csr1000v-universalk9.16.04.01.qcow2
-VERSION=$(shell echo $(IMAGE) | sed -e 's/.\+[^0-9]\([0-9]\+\.[0-9]\+\.[0-9]\+[sb]\?\?\)\([^0-9].*\|$$\)/\1/')
+VERSION=$(shell echo $(IMAGE) | sed -e 's/.\+[^0-9]\([0-9]\+\.[0-9]\+\.[0-9]\+[a-z]\?\)\([^0-9].*\|$$\)/\1/')
 
 -include ../makefile-sanity.include
 -include ../makefile.include

--- a/csr/docker/Dockerfile
+++ b/csr/docker/Dockerfile
@@ -14,6 +14,8 @@ RUN apt-get update -qy \
     genisoimage \
  && rm -rf /var/lib/apt/lists/*
 
+ARG VERSION
+ENV VERSION=${VERSION}
 ARG IMAGE
 COPY $IMAGE* /
 COPY *.py /

--- a/csr/docker/launch.py
+++ b/csr/docker/launch.py
@@ -142,7 +142,10 @@ class CSR_vm(vrnetlab.VM):
 
         self.wait_write("hostname csr1000v")
         self.wait_write("username %s privilege 15 password %s" % (self.username, self.password))
-        self.wait_write("ip domain-name example.com")
+        if int(self.version.split('.')[0]) >= 16:
+           self.wait_write("ip domain name example.com")
+        else:
+           self.wait_write("ip domain-name example.com")
         self.wait_write("crypto key generate rsa modulus 2048")
 
         self.wait_write("interface GigabitEthernet1")

--- a/makefile.include
+++ b/makefile.include
@@ -26,7 +26,7 @@ docker-build-common: docker-clean-build docker-pre-build
 	@echo "Building docker image using $(IMAGE) as $(REGISTRY)vr-$(VR_NAME):$(VERSION)"
 	cp ../common/* docker/
 	$(MAKE) IMAGE=$$IMAGE docker-build-image-copy
-	(cd docker; docker build --build-arg http_proxy=$(http_proxy) --build-arg https_proxy=$(https_proxy) --build-arg IMAGE=$(IMAGE) -t $(REGISTRY)vr-$(VR_NAME):$(VERSION) .)
+	(cd docker; docker build --build-arg http_proxy=$(http_proxy) --build-arg https_proxy=$(https_proxy) --build-arg IMAGE=$(IMAGE) --build-arg VERSION=$(VERSION) -t $(REGISTRY)vr-$(VR_NAME):$(VERSION) .)
 
 docker-build: docker-build-common
 

--- a/vmx/docker/Dockerfile
+++ b/vmx/docker/Dockerfile
@@ -13,6 +13,8 @@ RUN apt-get update -qy \
     qemu-kvm \
  && rm -rf /var/lib/apt/lists/*
 
+ARG VERSION
+ENV VERSION=${VERSION}
 COPY vmx /vmx
 COPY *.py /
 COPY juniper.conf /

--- a/vmx/docker/launch.py
+++ b/vmx/docker/launch.py
@@ -273,17 +273,16 @@ class VMX(vrnetlab.VR):
 
     def __init__(self, username, password, dual_re=False):
         self.version = None
-        self.version_info = []
         self.read_version()
         self.dual_re = dual_re
 
         super(VMX, self).__init__(username, password)
 
         if not dual_re:
-            self.vms = [ VMX_vcp(username, password, self.vcp_image, self.version), VMX_vfpc(self.version) ]
+            self.vms = [ VMX_vcp(username, password, self.vcp_image), VMX_vfpc(self.version) ]
         else:
-            self.vms = [ VMX_vcp(username, password, self.vcp_image, self.version, dual_re=True, re_instance=0),
-                         VMX_vcp(username, password, self.vcp_image, self.version, dual_re=True, re_instance=1),
+            self.vms = [ VMX_vcp(username, password, self.vcp_image, dual_re=True, re_instance=0),
+                         VMX_vcp(username, password, self.vcp_image, dual_re=True, re_instance=1),
                          VMX_vfpc(self.version) ]
 
 
@@ -298,7 +297,6 @@ class VMX(vrnetlab.VR):
             if m:
                 self.vcp_image = e
                 self.version = m.group(1)
-                self.version_info = [int(m.group(2)), int(m.group(3)), m.group(4), int(m.group(5)), int(m.group(7))]
 
     def start(self):
         # Set up socats for re1, with a different offset: $CONTAINER_IP:1022 -> 10.0.0.16:3022
@@ -319,7 +317,6 @@ class VMX_installer(VMX):
     """
     def __init__(self, username, password, dual_re=False):
         self.version = None
-        self.version_info = []
         self.read_version()
 
         super().__init__(username, password, dual_re)


### PR DESCRIPTION
IOS XE 16+ changed the `ip domain name ` command. Rather than trying to parse the version out from the disk image in the launch script, I opted to reuse the version extraction regex in the makefile. The `VERSION` variable is already used to create the container image tag, it is now also passed to the launch script via an environment variable.

Closes #312 
