### PR TITLE
Cleaning up an error message

### DIFF
--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -343,6 +343,7 @@ class SROS(vrnetlab.VR):
                 major_release = int(match.group(1))
             if re.search("\.qcow2$", e):
                 os.rename("/" + e, "/sros.qcow2")
+
             if re.search("\.license$", e):
                 os.rename("/" + e, "/tftpboot/license.txt")
 
@@ -354,9 +355,15 @@ class SROS(vrnetlab.VR):
         self.logger.info("Number of NICS: " + str(num_nics))
         self.logger.info("Mode: " + str(mode))
         # if we have more than 5 NICs or version is 19 or higher we use distributed VSR-SIM
-        if num_nics > 5 or major_release >= 19:
+        max_non_licensed_nics = 5
+        min_non_licensed_major_release = 19
+        if num_nics > max_non_licensed_nics or major_release >= min_non_licensed_major_release:
             if not self.license:
-                self.logger.error("More than 5 NICs require distributed VSR which requires a license but no license is found")
+                self.logger.error("More than {} ({} configured) NICs or a major version less than {} ({} detected)".format(max_non_licensed_nics,
+                                                                                                                        num_nics,
+                                                                                                                        min_non_licensed_major_release,
+                                                                                                                        major_release) +\
+                                  " require distributed VSR which requires a license but no license is found")
                 sys.exit(1)
 
             num_lc = math.ceil(num_nics / 6)

--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -343,7 +343,6 @@ class SROS(vrnetlab.VR):
                 major_release = int(match.group(1))
             if re.search("\.qcow2$", e):
                 os.rename("/" + e, "/sros.qcow2")
-
             if re.search("\.license$", e):
                 os.rename("/" + e, "/tftpboot/license.txt")
 


### PR DESCRIPTION
This error message neglects the fact that it could be the major revision that is the problem, not the number of nics.