### PR TITLE
Specify backing image format

### DIFF
--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -235,7 +235,7 @@ class VM:
         """
         if not os.path.exists(self.overlay_disk_image):
             self.logger.debug("Creating overlay disk image")
-            run_command(["qemu-img", "create", "-f", "qcow2", "-b", self.image, self.overlay_disk_image])
+            run_command(["qemu-img", "create", "-f", "qcow2", "-F", "qcow2", "-b", self.image, self.overlay_disk_image])
         return ["-drive", "if=ide,file=%s" % self.overlay_disk_image]
 
 

--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -235,7 +235,13 @@ class VM:
         """
         if not os.path.exists(self.overlay_disk_image):
             self.logger.debug("Creating overlay disk image")
-            run_command(["qemu-img", "create", "-f", "qcow2", "-F", "qcow2", "-b", self.image, self.overlay_disk_image])
+            extension = os.path.splitext(self.image)[1][1:]
+            fmtmap = {'img': 'raw'}
+            if extension in fmtmap:
+                backing_fmt = fmtmap[extension]
+            else:
+                backing_fmt = extension
+            run_command(["qemu-img", "create", "-f", "qcow2", "-F", backing_fmt, "-b", self.image, self.overlay_disk_image])
         return ["-drive", "if=ide,file=%s" % self.overlay_disk_image]
 
 


### PR DESCRIPTION
On new versions of QEMU, a "convert" call without this patch will fail with "Backing file specified without backing format":

Before:

```
2023-07-06 13:02:26,563: vrnetlab   DEBUG    Creating overlay disk image
qemu-img: /ffp-12.1X47-D15.4-packetmode-0-overlay.qcow2: Backing file specified without backing format
Detected format of qcow2.2023-07-06 13:02:26,587: vrnetlab   DEBUG    Starting vrnetlab <__main__.VSRX object at 0x7facd1bede50>
2023-07-06 13:02:26,587: vrnetlab   DEBUG    VMs: [<__main__.VSRX_vm object at 0x7facd1bee6d0>]
2023-07-06 13:02:26,589: vrnetlab   DEBUG    VM not started; starting!
2023-07-06 13:02:26,589: vrnetlab   INFO     Starting VSRX_vm[0]
2023-07-06 13:02:26,589: vrnetlab   DEBUG    ['qemu-system-x86_64', '-enable-kvm', '-display', 'none', '-machine', 'pc', '-monitor', 'tcp:0.0.0.0:4000,server,nowait', '-m', '2048', '
-serial', 'telnet:0.0.0.0:5000,server,nowait', '-drive', 'if=ide,file=/ffp-12.1X47-D15.4-packetmode-0-overlay.qcow2', '-smp', '2', '-device', 'pci-bridge,chassis_nr=1,id=pci.1', '-de
vice', 'virtio-net-pci,netdev=p00,mac=52:54:00:79:ab:00', '-netdev', 'user,id=p00,net=10.0.0.0/24,tftp=/tftpboot,hostfwd=tcp::2830-10.0.0.15:830,hostfwd=tcp::2080-10.0.0.15:80,hostfw
d=udp::2161-10.0.0.15:161,hostfwd=tcp::2443-10.0.0.15:443,hostfwd=tcp::2022-10.0.0.15:22', '-device', 'virtio-net-pci,netdev=p01,mac=52:54:00:a1:01:01,bus=pci.1,addr=0x2', '-netdev',
 'socket,id=p01,listen=:10001', '-device', 'virtio-net-pci,netdev=p02,mac=52:54:00:33:ff:02,bus=pci.1,addr=0x3', '-netdev', 'socket,id=p02,listen=:10002', '-device', 'virtio-net-pci,
netdev=p03,mac=52:54:00:8f:21:03,bus=pci.1,addr=0x4', '-netdev', 'socket,id=p03,listen=:10003', '-device', 'virtio-net-pci,netdev=p04,mac=52:54:00:34:53:04,bus=pci.1,addr=0x5', '-net
dev', 'socket,id=p04,listen=:10004', '-device', 'virtio-net-pci,netdev=p05,mac=52:54:00:25:da:05,bus=pci.1,addr=0x6', '-netdev', 'socket,id=p05,listen=:10005', '-device', 'virtio-net
-pci,netdev=p06,mac=52:54:00:07:7a:06,bus=pci.1,addr=0x7', '-netdev', 'socket,id=p06,listen=:10006', '-device', 'virtio-net-pci,netdev=p07,mac=52:54:00:64:3a:07,bus=pci.1,addr=0x8',
'-netdev', 'socket,id=p07,listen=:10007', '-device', 'virtio-net-pci,netdev=p08,mac=52:54:00:2d:a0:08,bus=pci.1,addr=0x9', '-netdev', 'socket,id=p08,listen=:10008', '-device', 'virti
o-net-pci,netdev=p09,mac=52:54:00:fa:d4:09,bus=pci.1,addr=0xa', '-netdev', 'socket,id=p09,listen=:10009', '-device', 'virtio-net-pci,netdev=p10,mac=52:54:00:0c:9a:0a,bus=pci.1,addr=0
xb', '-netdev', 'socket,id=p10,listen=:10010']
2023-07-06 13:02:26,639: vrnetlab   INFO     STDOUT:
2023-07-06 13:02:26,639: vrnetlab   INFO     STDERR: qemu-system-x86_64: -drive if=ide,file=/ffp-12.1X47-D15.4-packetmode-0-overlay.qcow2: Could not open '/ffp-12.1X47-D15.4-packetmo
de-0-overlay.qcow2': No such file or directory
```

After:

```
2023-07-06 13:19:14,964: vrnetlab   DEBUG    Creating overlay disk image
2023-07-06 13:19:14,994: vrnetlab   DEBUG    Starting vrnetlab <__main__.VSRX object at 0x7f21da75e4d0>
2023-07-06 13:19:14,994: vrnetlab   DEBUG    VMs: [<__main__.VSRX_vm object at 0x7f21da75e550>]
2023-07-06 13:19:14,996: vrnetlab   DEBUG    VM not started; starting!
2023-07-06 13:19:14,996: vrnetlab   INFO     Starting VSRX_vm[0]
2023-07-06 13:19:14,996: vrnetlab   DEBUG    ['qemu-system-x86_64', '-enable-kvm', '-display', 'none', '-machine', 'pc', '-monitor', 'tcp:0.0.0.0:4000,server,nowait', '-m', '2048', '
-serial', 'telnet:0.0.0.0:5000,server,nowait', '-drive', 'if=ide,file=/ffp-12.1X47-D15.4-packetmode-0-overlay.qcow2', '-smp', '2', '-device', 'pci-bridge,chassis_nr=1,id=pci.1', '-de
vice', 'virtio-net-pci,netdev=p00,mac=52:54:00:fb:aa:00', '-netdev', 'user,id=p00,net=10.0.0.0/24,tftp=/tftpboot,hostfwd=tcp::2443-10.0.0.15:443,hostfwd=tcp::2022-10.0.0.15:22,hostfw
d=udp::2161-10.0.0.15:161,hostfwd=tcp::2830-10.0.0.15:830,hostfwd=tcp::2080-10.0.0.15:80', '-device', 'virtio-net-pci,netdev=p01,mac=52:54:00:39:1b:01,bus=pci.1,addr=0x2', '-netdev',
 'socket,id=p01,listen=:10001', '-device', 'virtio-net-pci,netdev=p02,mac=52:54:00:1c:b9:02,bus=pci.1,addr=0x3', '-netdev', 'socket,id=p02,listen=:10002', '-device', 'virtio-net-pci,
netdev=p03,mac=52:54:00:7f:2e:03,bus=pci.1,addr=0x4', '-netdev', 'socket,id=p03,listen=:10003', '-device', 'virtio-net-pci,netdev=p04,mac=52:54:00:d2:f7:04,bus=pci.1,addr=0x5', '-net
dev', 'socket,id=p04,listen=:10004', '-device', 'virtio-net-pci,netdev=p05,mac=52:54:00:25:cc:05,bus=pci.1,addr=0x6', '-netdev', 'socket,id=p05,listen=:10005', '-device', 'virtio-net
-pci,netdev=p06,mac=52:54:00:12:33:06,bus=pci.1,addr=0x7', '-netdev', 'socket,id=p06,listen=:10006', '-device', 'virtio-net-pci,netdev=p07,mac=52:54:00:19:a2:07,bus=pci.1,addr=0x8',
'-netdev', 'socket,id=p07,listen=:10007', '-device', 'virtio-net-pci,netdev=p08,mac=52:54:00:34:c4:08,bus=pci.1,addr=0x9', '-netdev', 'socket,id=p08,listen=:10008', '-device', 'virti
o-net-pci,netdev=p09,mac=52:54:00:1b:92:09,bus=pci.1,addr=0xa', '-netdev', 'socket,id=p09,listen=:10009', '-device', 'virtio-net-pci,netdev=p10,mac=52:54:00:ed:c3:0a,bus=pci.1,addr=0
xb', '-netdev', 'socket,id=p10,listen=:10010']
2023-07-06 13:19:50,511: launch     INFO     VM started
```