### PR TITLE
Use single WriteFile actor for serializing file writes

### DIFF
--- a/vr-xcon/xcon.act
+++ b/vr-xcon/xcon.act
@@ -5,6 +5,9 @@ import file
 actor Healthcheck(write_file_auth, expected):
     # keep track of TcpEndpoint actor states (ids, like "r1/1")
     var states = {}
+    # Single actor for writing to the file to ensure the updates are flushed in
+    # the same order as they are received by Healthcheck.
+    var wf = file.WriteFile(write_file_auth, "health")
 
     def update(endpoint, state):
         states[endpoint] = state
@@ -23,10 +26,8 @@ actor Healthcheck(write_file_auth, expected):
             message = "Expected %d sockets but only %d connected" % (expected, count)
         print("healthcheck: %d (%s)" % (exit_code, message))
 
-        wf = file.WriteFile(write_file_auth, "health")
         health = "%d\n%s" % (exit_code, message)
         wf.write(health.encode())
-        wf.close()
 
     _flush()
 


### PR DESCRIPTION
We have many `TcpEndpoint` actors all pushing their internal state changes to the `Healthcheck` actor with `Healthcheck.update()`. These calls are serialized and processed in the order they arrive (?). The internal `Healthcheck._flush()` method then uses a single `file.WriteFile` actor to serialize writes to the "/health" file. If we did not do that and used a *new* `file.WriteFile` actor directly (like we used to), there is a race between the different `file.WriteFile` actors and a chance of inconsistent state written to the file.