### PR TITLE
Extend 'run_args' in topomachine to support lists, dicts

### DIFF
--- a/topology-machine/README.md
+++ b/topology-machine/README.md
@@ -188,19 +188,20 @@ generate the docker run commands:
 ```
 $ docker run -v $(pwd):/data topomachine --run /data/example-lltopo.json --dry-run
 The following commands would be executed:
-docker run --privileged -d --name ams-core-1 vr-xrv:5.1.1.54U
-docker run --privileged -d --name ams-core-2 vr-xrv:5.1.1.54U
-docker run --privileged -d --name ams-edge-1 vr-xrv:5.1.1.54U
-docker run --privileged -d --name fra-core-1 vr-vmx:16.1R1.7
-docker run --privileged -d --name fra-core-2 vr-vmx:16.1R1.7
-docker run --privileged -d --name fra-edge-1 vr-vmx:16.1R1.7
-docker run --privileged -d --name kul-core-1 vr-xrv:5.1.1.54U
-docker run --privileged -d --name par-core-1 vr-sros:13.0.B1-4281
-docker run --privileged -d --name par-core-2 vr-sros:13.0.B1-4281
-docker run --privileged -d --name par-edge-1 vr-sros:13.0.B1-4281
-docker run --privileged -d --name png-edge-1 vr-xrv:5.1.1.54U
-docker run --privileged -d --name sgp-core-1 vr-xrv:5.1.1.54U
-docker run --privileged -d --name vr-xcon --link ams-core-1:ams-core-1 --link ams-core-2:ams-core-2 --link ams-edge-1:ams-edge-1 --link fra-core-1:fra-core-1 --link fra-core-2:fra-core-2 --link fra-edge-1:fra-edge-1 --link kul-core-1:kul-core-1 --link par-core-1:par-core-1 --link par-core-2:par-core-2 --link par-edge-1:par-edge-1 --link png-edge-1:png-edge-1 --link sgp-core-1:sgp-core-1 vr-xcon --p2p ams-edge-1/1--ams-core-1/1 ams-edge-1/2--ams-core-2/1 fra-core-2/1--sgp-core-1/1 fra-core-2/2--kul-core-1/1 fra-edge-1/1--fra-core-1/1 fra-edge-1/2--fra-core-2/3 par-core-1/1--sgp-core-1/2 par-core-1/2--kul-core-1/2 par-edge-1/1--par-core-1/3 par-edge-1/2--par-core-2/1 png-edge-1/1--sgp-core-1/3 png-edge-1/2--kul-core-1/3 kul-core-1/4--sgp-core-1/4 ams-core-1/2--ams-core-2/2 ams-core-1/3--fra-core-1/2 ams-core-1/4--fra-core-2/4 ams-core-1/5--par-core-1/4 ams-core-1/6--par-core-2/2 ams-core-2/3--fra-core-1/3 ams-core-2/4--fra-core-2/5 ams-core-2/5--par-core-1/5 ams-core-2/6--par-core-2/3 fra-core-1/4--fra-core-2/6 fra-core-1/5--par-core-1/6 fra-core-1/6--par-core-2/4 fra-core-2/7--par-core-1/7 fra-core-2/8--par-core-2/5 par-core-1/8--par-core-2/6
+docker run --privileged -d --name ams-core-1 vrnetlab/vr-xrv:5.1.1.54U --foo bar 1
+docker run --privileged -d --name ams-core-2 vrnetlab/vr-xrv:5.1.1.54U --foo bar 1
+docker run --privileged -d --name ams-edge-1 vrnetlab/vr-xrv:5.1.1.54U
+docker run --privileged -d --name fra-core-1 vrnetlab/vr-vmx:16.1R1.7 --foo ['bar', 1]
+docker run --privileged -d --name fra-core-2 vrnetlab/vr-vmx:16.1R1.7
+docker run --privileged -d --name fra-edge-1 vrnetlab/vr-vmx:16.1R1.7
+docker run --privileged -d --name kul-core-1 vrnetlab/vr-xrv:5.1.1.54U
+docker run --privileged -d --name par-core-1 vrnetlab/vr-sros:13.0.B1-4281
+docker run --privileged -d --name par-core-2 vrnetlab/vr-sros:13.0.B1-4281
+docker run --privileged -d --name par-edge-1 vrnetlab/vr-sros:13.0.B1-4281
+docker run --privileged -d --name png-edge-1 vrnetlab/vr-xrv:5.1.1.54U
+docker run --privileged -d --name sgp-core-1 vrnetlab/vr-xrv:5.1.1.54U
+docker run --rm --privileged -d --name vr-xcon --link ams-core-1:ams-core-1 --link ams-core-2:ams-core-2 --link ams-edge-1:ams-edge-1 --link fra-core-1:fra-core-1 --link fra-core-2:fra-core-2 --link fra-edge-1:fra-edge-1 --link kul-core-1:kul-core-1 --link par-core-1:par-core-1 --link par-core-2:par-core-2 --link par-edge-1:par-edge-1 --link png-edge-1:png-edge-1 --link sgp-core-1:sgp-core-1 vrnetlab/vr-xcon --p2p ams-edge-1/1--ams-core-1/1 ams-edge-1/2--ams-core-2/1 fra-core-2/1--sgp-core-1/1 fra-core-2/2--kul-core-1/1 fra-edge-1/1--fra-core-1/1 fra-edge-1/2--fra-core-2/3 par-core-1/1--sgp-core-1/2 par-core-1/2--kul-core-1/2 par-edge-1/1--par-core-1/3 par-edge-1/2--par-core-2/1 png-edge-1/1--sgp-core-1/3 png-edge-1/2--kul-core-1/3 kul-core-1/4--sgp-core-1/4 ams-core-1/2--ams-core-2/2 ams-core-1/3--fra-core-1/2 ams-core-1/4--fra-core-2/4 ams-core-1/5--par-core-1/4 ams-core-1/6--par-core-2/2 ams-core-2/3--fra-core-1/3 ams-core-2/4--fra-core-2/5 ams-core-2/5--par-core-1/5 ams-core-2/6--par-core-2/3 fra-core-1/4--fra-core-2/6 fra-core-1/5--par-core-1/6 fra-core-1/6--par-core-2/4 fra-core-2/7--par-core-1/7 fra-core-2/8--par-core-2/5 par-core-1/8--par-core-2/6
+docker run --privileged -d --name vr-xcon-hub-ams-mgmt --link ams-core-1:ams-core-1 --link ams-core-2:ams-core-2 --link ams-edge-1:ams-edge-1 --link fra-core-1:fra-core-1 --link fra-core-2:fra-core-2 --link fra-edge-1:fra-edge-1 --link kul-core-1:kul-core-1 --link par-core-1:par-core-1 --link par-core-2:par-core-2 --link par-edge-1:par-edge-1 --link png-edge-1:png-edge-1 --link sgp-core-1:sgp-core-1 vrnetlab/vr-xcon --hub ams-core-1/7 ams-core-2/7 ams-edge-1/3
 ```
 
 start the topology:

--- a/topology-machine/example-hltopo.json
+++ b/topology-machine/example-hltopo.json
@@ -1,8 +1,8 @@
 {
 	"routers": {
-		"ams-core-1": { "id": 1, "type": "xrv", "version": "5.1.1.54U" },
-		"ams-core-2": { "id": 2, "type": "xrv", "version": "5.1.1.54U" },
-		"fra-core-1": { "id": 3, "type": "vmx", "version": "16.1R1.7" },
+		"ams-core-1": { "id": 1, "type": "xrv", "version": "5.1.1.54U", "run_args": "--foo bar 1" },
+		"ams-core-2": { "id": 2, "type": "xrv", "version": "5.1.1.54U", "run_args": ["--foo", "bar", 1] },
+		"fra-core-1": { "id": 3, "type": "vmx", "version": "16.1R1.7", "run_args": { "--foo": [ "bar", 1 ] } },
 		"fra-core-2": { "id": 4, "type": "vmx", "version": "16.1R1.7" },
 		"par-core-1": { "id": 5, "type": "sros", "version": "13.0.B1-4281" },
 		"par-core-2": { "id": 6, "type": "sros", "version": "13.0.B1-4281" },

--- a/topology-machine/topomachine
+++ b/topology-machine/topomachine
@@ -238,7 +238,14 @@ def run_topology(config, dry_run, with_trace=False, xcon_ng=False):
         if trace:
             cmd.append(trace)
         if 'run_args' in val:
-            cmd.extend(val["run_args"].split())
+            if isinstance(val['run_args'], str):
+                cmd.extend(val["run_args"].split())
+            # pass the keys and values unquoted, leave it up to the user to quote/escape or add dashes
+            elif isinstance(val['run_args'], list):
+                cmd.extend([str(v) for v in val['run_args']])
+            elif isinstance(val['run_args'], dict):
+                for k, v in val['run_args'].items():
+                    cmd.extend([str(k), str(v)])
 
         output,_ = run_command(["docker", "inspect", "--format", "{{.State.Running}}", name])
         if not dry_run and output.strip() == "true":


### PR DESCRIPTION
topomachine already supports `run_args` for passing a raw string containing all the arguments to a container. With `run_args_structured` we can keep the structure in JSON and then pass the arguments as:
- a list,
- as key value pairs

to the container. Note how the values are passed verbatim - there are no assumptions about prefixing the key names with '--' or quoting the values. 