### PR TITLE
Add --keep-order to topomachine

### DIFF
--- a/topology-machine/README.md
+++ b/topology-machine/README.md
@@ -34,6 +34,15 @@ topomachine does not currently use any information from the low level topology
 will very likely result in changes to the majority of links in the topology as
 they will be re-assigned to new interfaces.
 
+The default behavior is to sort the routers and links and assign interfaces
+numbers to links in this sorted order. There is however an option called
+`--keep-order` that will take into account the order in which the *p2p* links
+and routers in *fullmeshes* are defined in the configuration file. This makes
+the interface assignment more stable when changing the topology. It also makes
+the assignment more natural, as we tend to list the important routers (like PE
+routers) in the topology first, followed by CPEs and the like. The interfaces on
+the devices listed first will be assigned lower numbers.
+
 topology machine is able to run the machines for you, i.e. execute docker run
 for the routers defined in the configuration file and start vr-xcon with the
 relevant arguments to complete the topology:

--- a/topology-machine/topomachine
+++ b/topology-machine/topomachine
@@ -27,10 +27,17 @@ class VrTopo:
             if val['type'] not in ('dummy', 'xcon', 'bgp', 'xrv', 'xrv9k', 'vmx', 'sros', 'csr', 'nxos', 'nxos9kv', 'vqfx', 'vrp', 'veos', 'openwrt'):
                 raise ValueError("Unknown type %s for router %s" % (val['type'], r))
 
+        # preserve order of entries if keep_order is set
+        def maybe_sorted(d):
+            if keep_order:
+                return d
+            else:
+                return sorted(d)
+
         # expand p2p links
         links = []
         if 'p2p' in config:
-            for router in sorted(config['p2p']):
+            for router in maybe_sorted(config['p2p']):
                 neighbors = config['p2p'][router]
                 for neighbor in neighbors:
                     links.append({ 'left': { 'router': router }, 'right': {
@@ -38,7 +45,7 @@ class VrTopo:
 
         # expand fullmesh into links
         if 'fullmeshes' in config:
-            for name in sorted(config['fullmeshes']):
+            for name in maybe_sorted(config['fullmeshes']):
                 val = config['fullmeshes'][name]
                 fmlinks = self.expand_fullmesh(val)
                 links.extend(fmlinks)

--- a/topology-machine/topomachine
+++ b/topology-machine/topomachine
@@ -10,13 +10,15 @@ import jinja2
 class VrTopo:
     """ vrnetlab topo builder
     """
-    def __init__(self, config):
-        self.routers = {}
+    def __init__(self, config, keep_order):
+        self.keep_order = keep_order
         self.links = []
         self.fullmeshes = {}
         self.hubs = {}
         if 'routers' in config:
             self.routers = config['routers']
+        else:
+            self.routers = {}
 
         # sanity checking - use a YANG model and pyang to validate input?
         for r, val in self.routers.items():
@@ -179,7 +181,7 @@ class VrTopo:
             }
 
         if output_format == 'json':
-            return json.dumps(output, sort_keys=True, indent=4)
+            return json.dumps(output, sort_keys=(not self.keep_order), indent=4)
         else:
             raise ValueError("Invalid output format")
 
@@ -299,6 +301,7 @@ if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser()
     parser.add_argument("--build", help="Build topology from config")
+    parser.add_argument("--keep-order", action="store_true", help="Keep topology order (routers, links, fullmeshes). Applies to --build only")
     parser.add_argument("--run", help="Run topology")
     parser.add_argument("--dry-run", action="store_true", default=False, help="Only print what would be performed during --run")
     parser.add_argument("--prefix", default='', help="docker container name prefix")
@@ -321,7 +324,7 @@ if __name__ == '__main__':
         config = json.loads(input_file.read(), object_pairs_hook=OrderedDict)
         input_file.close()
         try:
-            vt = VrTopo(config)
+            vt = VrTopo(config, args.keep_order)
         except Exception as exc:
             print("ERROR:", exc)
             sys.exit(1)

--- a/topology-machine/topomachine
+++ b/topology-machine/topomachine
@@ -34,21 +34,34 @@ class VrTopo:
             else:
                 return sorted(d)
 
-        # expand p2p links
         links = []
-        if 'p2p' in config:
-            for router in maybe_sorted(config['p2p']):
-                neighbors = config['p2p'][router]
-                for neighbor in neighbors:
-                    links.append({ 'left': { 'router': router }, 'right': {
-                        'router': neighbor }})
+
+        # expand p2p links
+        def p2p():
+            nonlocal links
+            if 'p2p' in config:
+                for router in maybe_sorted(config['p2p']):
+                    neighbors = config['p2p'][router]
+                    for neighbor in neighbors:
+                        links.append({ 'left': { 'router': router }, 'right': {
+                            'router': neighbor }})
 
         # expand fullmesh into links
-        if 'fullmeshes' in config:
-            for name in maybe_sorted(config['fullmeshes']):
-                val = config['fullmeshes'][name]
-                fmlinks = self.expand_fullmesh(val)
-                links.extend(fmlinks)
+        def fullmesh():
+            nonlocal links
+            if 'fullmeshes' in config:
+                for name in maybe_sorted(config['fullmeshes']):
+                    val = config['fullmeshes'][name]
+                    fmlinks = self.expand_fullmesh(val)
+                    links.extend(fmlinks)
+
+        # expand fullmeshes before p2p if keep_order is set and fullmeshes is defined before p2p
+        if keep_order and 'fullmeshes' in config and 'p2p' in config and tuple(config).index('fullmeshes') < tuple(config).index('p2p'):
+            fullmesh()
+            p2p()
+        else:
+            p2p()
+            fullmesh()
 
         self.links = self.assign_interfaces(links)
 
@@ -82,9 +95,8 @@ class VrTopo:
                 for num_id in val['interfaces']:
                     val['interfaces'][num_id] = self.intf_num_to_name(router, num_id)
 
-
-
-    def expand_fullmesh(self, routers):
+    @staticmethod
+    def expand_fullmesh(routers):
         """ Flatten a full-mesh into a list of links
 
             Links are considered bi-directional, so you will only see a link A->B


### PR DESCRIPTION
This PR proposes a new `--keep-order` option for topomachine that takes into account the order in which *p2p* links and routers in *fullmeshes* are defined. When topomachine produces the low-level topology JSON (`--build` command) it first sorts the routers and links. As far as I can tell this was added back in the day when iterating a Python dictionary was not guaranteed to be in any order (of insertion or otherwise sorted) as a means of guaranteeing stable output ✝️. And it does work, but sometimes the assigned interface IDs are unexpected. Take this topology definition, consisting of 3 "core" routers connected in full mesh and each code router has a pc attached.

```json
{
	"routers": {
		"vr1": { "type": "vmx" },
		"vr2": { "type": "vmx" },
		"vr3": { "type": "vmx" },
		"pc1": { "type": "vmx" },
		"pc2": { "type": "vmx" },
		"pc3": { "type": "vmx" }
	},
    "fullmeshes": {
		"core": [ "vr1", "vr2", "vr3" ]
	},
	"p2p": {
		"vr1": [ "pc1" ],
		"vr2": [ "pc2" ],
		"vr3": [ "pc3" ]
	}
}
```

A human would naturally use the lower ID interfaces for building the core full mesh first and then add the pc links. But not topomachine! These are the expanded p2p links after sorting the input: `vr1/1--pc1/1 vr2/1--pc2/1 vr3/1--pc3/1 vr1/2--vr2/2 vr1/3--vr3/2 vr2/3--vr3/3`. With the new `--keep-order` option we get this: `vr1/1--vr2/1 vr1/2--vr3/1 vr2/2--vr3/2 vr1/3--pc1/1 vr2/3--pc2/1 vr3/3--pc3/1`. The overall output is still stable when using Python 3.7+.

✝️ Python 3.7 has changed this - [Dictionary order is guaranteed to be insertion order]. Considering Python 3.7 is EOL as of 2023.06 we can take this for granted?

[Dictionary order is guaranteed to be insertion order]: https://docs.python.org/3/library/stdtypes.html#dictionary-view-objects