### PR TITLE
Support double-digit version numbers in xrv(9k)

### DIFF
--- a/xrv/Makefile
+++ b/xrv/Makefile
@@ -9,7 +9,7 @@ IMAGE_GLOB=*vmdk*
 # iosxrv-k9-demo-6.2.2.15I.DT_IMAGE.vmdk
 # iosxrv-k9-demo-6.2.2.1T-dhcpfix.vmdk
 # iosxrv-k9-demo-6.2.2.22I.vmdk
-VERSION=$(shell echo $(IMAGE) | sed -e 's/.\+[^0-9][^0-9]\([0-9]\.[0-9]\.[0-9]\(\.[0-9A-Z]\+\)\?\)\([^0-9].*\|$$\)/\1/')
+VERSION=$(shell echo $(IMAGE) | sed -e 's/.\+[^0-9]\([0-9]\+\.[0-9]\+\.[0-9]\+\(\.[0-9A-Z]\+\)\?\)\([^0-9].*\|$$\)/\1/')
 
 -include ../makefile-sanity.include
 -include ../makefile.include

--- a/xrv9k/Makefile
+++ b/xrv9k/Makefile
@@ -7,7 +7,8 @@ IMAGE_GLOB=*qcow2*
 # TODO: add example file names here
 # xrv9k-fullk9-x.vrr-6.1.3.qcow2
 # xrv9k-fullk9-x.vrr-6.2.1.qcow2
-VERSION=$(shell echo $(IMAGE) | sed -e 's/.\+[^0-9]\([0-9]\.[0-9]\.[0-9]\(\.[0-9A-Z]\+\)\?\)\([^0-9].*\|$$\)/\1/')
+# xrv9k-fullk9-x-7.10.1.qcow2
+VERSION=$(shell echo $(IMAGE) | sed -e 's/.\+[^0-9]\([0-9]\+\.[0-9]\+\.[0-9]\+\(\.[0-9A-Z]\+\)\?\)\([^0-9].*\|$$\)/\1/')
 
 -include ../makefile-sanity.include
 -include ../makefile.include


### PR DESCRIPTION
Fixes #332 