### PR TITLE
Update launch.py - change "self.spins > 60" to "self.spins > 600"

### DIFF
--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -72,7 +72,7 @@ class SROS_vm(vrnetlab.VM):
         """ This function should be called periodically to do work.
         """
 
-        if self.spins > 60:
+        if self.spins > 600:
             # too many spins with no result, probably means SROS hasn't started
             # successfully, so we restart it
             self.logger.warning("no output from serial console, restarting VM")


### PR DESCRIPTION
Older SROS releases require more time to boot. With 60s, booting SROS 20 in a VM results in continuous boots with the message: "no output from serial console, restarting VM"

Increasing to 300s or higher solves the issue.
Some colleagues report ~10m to boot with R12 or R14.