### PR TITLE
Delay overlay image creation until QEMU starts

### DIFF
--- a/csr/docker/launch.py
+++ b/csr/docker/launch.py
@@ -34,10 +34,11 @@ logging.Logger.trace = trace
 
 class CSR_vm(vrnetlab.VM):
     def __init__(self, username, password, install_mode=False):
-        for e in os.listdir("/"):
-            if re.search(".qcow2$", e):
+        disk_image = None
+        for e in sorted(os.listdir("/")):
+            if not disk_image and re.search(".qcow2$", e):
                 disk_image = "/" + e
-            if re.search("\.license$", e):
+            if re.search(r"\.license$", e):
                 os.rename("/" + e, "/tftpboot/license.lic")
 
         self.license = False

--- a/nxos/docker/launch.py
+++ b/nxos/docker/launch.py
@@ -34,8 +34,9 @@ logging.Logger.trace = trace
 
 class NXOS_vm(vrnetlab.VM):
     def __init__(self, username, password):
-        for e in os.listdir("/"):
-            if re.search(".qcow2$", e):
+        disk_image = None
+        for e in sorted(os.listdir("/")):
+            if not disk_image and re.search(".qcow2$", e):
                 disk_image = "/" + e
         super(NXOS_vm, self).__init__(username, password, disk_image=disk_image)
         self.num_nics = 144

--- a/nxos9kv/docker/launch.py
+++ b/nxos9kv/docker/launch.py
@@ -34,8 +34,9 @@ logging.Logger.trace = trace
 
 class NXOS9K_vm(vrnetlab.VM):
     def __init__(self, bios, username, password, num_nics):
-        for e in os.listdir("/"):
-            if re.search(".qcow2$", e):
+        disk_image = None
+        for e in sorted(os.listdir("/")):
+            if not disk_image and re.search(".qcow2$", e):
                 disk_image = "/" + e
         # the parent constructor needs to call create_overlay_image,
         # so must initialize the other parameters first

--- a/nxos9kv/docker/launch.py
+++ b/nxos9kv/docker/launch.py
@@ -49,22 +49,17 @@ class NXOS9K_vm(vrnetlab.VM):
 
 
     def create_overlay_image(self):
+        pre_start_cmds, _ = super().create_overlay_image()
         extended_args = ['-nographic', '-bios', self.bios, '-smp', '2']
-        # remove previously old overlay image, otherwise boot fails
-        if os.path.exists(self.overlay_disk_image):
-            os.remove(self.overlay_disk_image)
-        # now re-create it!
-        super().create_overlay_image()
         # use SATA driver for disk and set to drive 0
         extended_args.extend(['-device', 'ahci,id=ahci0,bus=pci.0',
             '-drive', 'if=none,file=%s,id=drive-sata-disk0,format=qcow2' % self.overlay_disk_image,
             '-device', 'ide-drive,bus=ahci0.0,drive=drive-sata-disk0,id=drive-sata-disk0'])
         # create initial config and load it
-        vrnetlab.run_command(['genisoimage', '-o', '/cfg.iso', '-l', '--iso-level', '2', 'nxos_config.txt'])
+        pre_start_cmds.append(['genisoimage', '-o', '/cfg.iso', '-l', '--iso-level', '2', 'nxos_config.txt'])
         extended_args.extend(['-drive', 'file=cfg.iso,media=cdrom'])
 
-
-        return extended_args
+        return pre_start_cmds, extended_args
 
     def bootstrap_spin(self):
         """ This function should be called periodically to do work.
@@ -76,10 +71,7 @@ class NXOS9K_vm(vrnetlab.VM):
         if self.spins > 300:
             # too many spins with no result ->  give up
             self.prompted = False
-            self.stop()
-            # re-create overlay image
-            self.create_overlay_image()
-            self.start()
+            self.restart()
             return
 
         username, password = self.credentials[0]

--- a/openwrt/docker/launch.py
+++ b/openwrt/docker/launch.py
@@ -30,8 +30,9 @@ logging.Logger.trace = trace
 
 class OpenWRT_vm(vrnetlab.VM):
     def __init__(self, username, password):
-        for e in os.listdir("/"):
-            if re.search(".img$", e):
+        disk_image = None
+        for e in sorted(os.listdir("/")):
+            if not disk_image and re.search(".img$", e):
                 disk_image = "/" + e
         super(OpenWRT_vm, self).__init__(username, password, disk_image=disk_image, ram=128)
         self.nic_type = "virtio-net-pci"

--- a/routeros/docker/launch.py
+++ b/routeros/docker/launch.py
@@ -30,8 +30,9 @@ logging.Logger.trace = trace
 
 class ROS_vm(vrnetlab.VM):
     def __init__(self, username, password):
-        for e in os.listdir("/"):
-            if re.search(".vmdk$", e):
+        disk_image = None
+        for e in sorted(os.listdir("/")):
+            if not disk_image and re.search(".vmdk$", e):
                 disk_image = "/" + e
         super(ROS_vm, self).__init__(username, password, disk_image=disk_image, ram=256)
         self.qemu_args.extend(["-boot", "n"])

--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -337,7 +337,7 @@ class SROS(vrnetlab.VR):
         major_release = 0
 
         # move files into place
-        for e in os.listdir("/"):
+        for e in sorted(os.listdir("/")):
             match = re.match(r'[^0-9]+([0-9]+)\S+\.qcow2$', e)
             if match:
                 major_release = int(match.group(1))

--- a/veos/docker/launch.py
+++ b/veos/docker/launch.py
@@ -34,10 +34,11 @@ logging.Logger.trace = trace
 
 class VEOS_vm(vrnetlab.VM):
     def __init__(self, username, password):
-        for e in os.listdir("/"):
-            if re.search(".vmdk$", e):
+        disk_image = None
+        for e in sorted(os.listdir("/")):
+            if not disk_image and re.search(".vmdk$", e):
                 disk_image = "/" + e
-        for e in os.listdir("/"):
+        for e in sorted(os.listdir("/")):
             if re.search(".iso$", e):
                 boot_iso = "/" + e
         super(VEOS_vm, self).__init__(username, password, disk_image=disk_image, ram=2048)

--- a/vqfx/docker/launch.py
+++ b/vqfx/docker/launch.py
@@ -31,7 +31,7 @@ logging.Logger.trace = trace
 
 class VQFX_vcp(vrnetlab.VM):
     def __init__(self, username, password):
-        for e in os.listdir("/"):
+        for e in sorted(os.listdir("/")):
             if re.search("-re-.*.vmdk", e):
                 vrnetlab.run_command(["qemu-img", "create", "-b", "/" + e, "-f", "qcow", "/vcp.qcow2"])
         super(VQFX_vcp, self).__init__(username, password, disk_image="/vcp.qcow2", ram=2048)
@@ -156,7 +156,7 @@ class VQFX_vcp(vrnetlab.VM):
 
 class VQFX_vpfe(vrnetlab.VM):
     def __init__(self):
-        for e in os.listdir("/"):
+        for e in sorted(os.listdir("/")):
             if re.search("-pfe-.*.vmdk", e):
                 vrnetlab.run_command(["qemu-img", "create", "-b", "/" + e, "-f", "qcow", "/vpfe.qcow2"])
         super(VQFX_vpfe, self).__init__(None, None, disk_image="/vpfe.qcow2", num=1, ram=2048)

--- a/vrp/docker/launch.py
+++ b/vrp/docker/launch.py
@@ -31,8 +31,9 @@ class simulator_VM(vrnetlab.VM):
     no_paging_command = 'screen-length 0 temporary'
 
     def __init__(self, username, password):
-        for e in os.listdir("/"):
-            if re.search(".qcow2$", e):
+        disk_image = None
+        for e in sorted(os.listdir("/")):
+            if not disk_image and  re.search(".qcow2$", e):
                 disk_image = "/" + e
 
         self.ram = 16384

--- a/vsr1000/docker/launch.py
+++ b/vsr1000/docker/launch.py
@@ -31,8 +31,9 @@ logging.Logger.trace = trace
 
 class VSR_vm(vrnetlab.VM):
     def __init__(self, username, password):
-        for e in os.listdir("/"):
-            if re.search(".qco$", e):
+        disk_image = None
+        for e in sorted(os.listdir("/")):
+            if not disk_image and re.search(".qco$", e):
                 disk_image = "/" + e
         super(VSR_vm, self).__init__(username, password, disk_image=disk_image, ram=1024)
 

--- a/xrv/docker/launch.py
+++ b/xrv/docker/launch.py
@@ -34,8 +34,9 @@ logging.Logger.trace = trace
 
 class XRV_vm(vrnetlab.VM):
     def __init__(self, username, password):
-        for e in os.listdir("/"):
-            if re.search(".vmdk", e):
+        disk_image = None
+        for e in sorted(os.listdir("/")):
+            if not disk_image and re.search(".vmdk", e):
                 disk_image = "/" + e
         super(XRV_vm, self).__init__(username, password, disk_image=disk_image, ram=3072)
         self.num_nics = 128

--- a/xrv9k/docker/launch.py
+++ b/xrv9k/docker/launch.py
@@ -34,8 +34,9 @@ logging.Logger.trace = trace
 
 class XRV_vm(vrnetlab.VM):
     def __init__(self, username, password, ram, nics, install_mode=False):
-        for e in os.listdir("/"):
-            if re.search(".qcow2", e):
+        disk_image = None
+        for e in sorted(os.listdir("/")):
+            if not disk_image and re.search(".qcow2", e):
                 disk_image = "/" + e
         super(XRV_vm, self).__init__(username, password, disk_image=disk_image,
                                      ram=ram*1024)


### PR DESCRIPTION
*Always* create the overlay disk image to avoid the potentially expensive copy-on-write operation for large files. We used to create overlay images right in `vrnetlab.VM.__init__()`. This makes it difficult to implement the `restart()` method correctly. The restart method is used to recover from an incorrect state so all modifications to the original image should be discarded.