### PR TITLE
Add Catalyst 8000v

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ['csr', 'nxos', 'nxos9kv', 'routeros', 'sros', 'ucpe-oneos', 'veos', 'vmx', 'vqfx', 'vrp', 'vsr1000', 'xrv', 'xrv9k']
+        platform: ['csr', 'c8000v', 'nxos', 'nxos9kv', 'routeros', 'sros', 'ucpe-oneos', 'veos', 'vmx', 'vqfx', 'vrp', 'vsr1000', 'xrv', 'xrv9k']
 
     steps:
       - uses: actions/checkout@v3

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,6 +55,9 @@ topology-machine:
 csr:
   <<: *build-template
 
+c8000v:
+  <<: *build-template
+
 nxos:
   <<: *build-template
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IMAGES_DIR=
-VRS = vr-xcon vr-bgp topology-machine csr nxos nxos9kv routeros sros ucpe-oneos veos vmx vsr1000 vqfx vrp xrv xrv9k
+VRS = vr-xcon vr-bgp topology-machine csr c8000v nxos nxos9kv routeros sros ucpe-oneos veos vmx vsr1000 vqfx vrp xrv xrv9k
 VRS_PUSH = $(VRS:=-push)
 VRS_TEST = $(VRS:=-test)
 

--- a/c8000v/Makefile
+++ b/c8000v/Makefile
@@ -6,7 +6,7 @@ IMAGE_GLOB=*.qcow2
 # match versions like:
 # csr1000v-universalk9.16.03.01a.qcow2
 # csr1000v-universalk9.16.04.01.qcow2
-VERSION=$(shell echo $(IMAGE) | sed -e 's/.\+[^0-9]\([0-9]\+\.[0-9]\+\.[0-9]\+[sb]\?\?\)\([^0-9].*\|$$\)/\1/')
+VERSION=$(shell echo $(IMAGE) | sed -e 's/.\+[^0-9]\([0-9]\+\.[0-9]\+\.[0-9]\+[a-z]\?\)\([^0-9].*\|$$\)/\1/')
 
 -include ../makefile-sanity.include
 -include ../makefile.include

--- a/c8000v/Makefile
+++ b/c8000v/Makefile
@@ -1,0 +1,18 @@
+VENDOR=Cisco
+NAME=c8000v
+IMAGE_FORMAT=qcow2
+IMAGE_GLOB=*.qcow2
+
+# match versions like:
+# csr1000v-universalk9.16.03.01a.qcow2
+# csr1000v-universalk9.16.04.01.qcow2
+VERSION=$(shell echo $(IMAGE) | sed -e 's/.\+[^0-9]\([0-9]\+\.[0-9]\+\.[0-9]\+[sb]\?\?\)\([^0-9].*\|$$\)/\1/')
+
+-include ../makefile-sanity.include
+-include ../makefile.include
+-include ../makefile-install.include
+
+docker-build: docker-build-common
+	docker run --cidfile cidfile --privileged $(REGISTRY)vr-$(VR_NAME):$(VERSION) --trace --install
+	docker commit --change='ENTRYPOINT ["/launch.py"]' $$(cat cidfile) $(REGISTRY)vr-$(VR_NAME):$(VERSION)
+	docker rm -f $$(cat cidfile)

--- a/c8000v/README.md
+++ b/c8000v/README.md
@@ -1,0 +1,109 @@
+vrnetlab / Cisco Catalyst 8000V Edge Software
+===========================
+This is the vrnetlab docker image for Cisco Catalyst 8000V Edge Software, or
+'c8000v' for short.
+
+The Catalyst 8000v platform is a successor to the CSR 1000v. As such, this
+platform directory 'c8000v' started off as a copy of the 'csr' directory. With
+time we imagine the two platforms will diverge. One such change is already
+planned to support using the Catalyst 8000v in one of the two modes:
+- regular,
+- SD-WAN Controller mode (managed by Viptela).
+
+Right now the SD-WAN flavor is still split off because to enable the Controller
+mode you have to effectively boot the router into a completely different mode.
+In the near future these modifications will be merged back into the 'c8000v'
+platform that will produce both the regular and sd-wan images.
+
+On installation of Catalyst 8000v the user is presented with the choice of
+output, which can be over serial console, a video console or through automatic
+detection of one or the other. Empirical studies show that the automatic
+detection is far from infallible and so we force the use of the serial console
+by feeding the VM an .iso image that contains a small bootstrap configuration
+that sets the output to serial console. This means we have to boot up the VM
+once to feed it this configuration and then restart it for the changes to take
+effect. Naturally we want to do this in the build process as to avoid having to
+restart the router once for every time we run the docker image. Unfortunately
+docker doesn't allow us to run docker build with `--privileged` so there is no
+KVM acceleration making this process excruciatingly slow were it to be performed
+in the docker build phase. Instead we build a basic image using docker build,
+which essentially just assembles the required files, then run it with
+`--privileged` to start up the VM and feed it the .iso image. After we are done
+we shut down the VM and commit this new state into the final docker image. This
+is unorthodox but works and saves us a lot of time.
+
+Building the docker image
+-------------------------
+Put the .qcow2 file in this directory and run `make docker-image` and you should
+be good to go. The resulting image is called `vr-c8000v`. You can tag it with
+something else if you want, like `my-repo.example.com/vr-c8000v` and then push
+it to your repo. The tag is the same as the version of the Catalyst 8000v image,
+so if you have c8000v-universalk9.16.04.01.qcow2 your final docker image will be
+called `vr-c8000v:16.04.01`
+
+Please note that you will always need to specify version when starting your
+router as the "latest" tag is not added to any images since it has no meaning
+in this context.
+
+It's been tested to boot and respond to SSH with:
+
+ * 16.03.01a (c8000v-universalk9.16.03.01a.qcow2)
+ * 16.04.01 (c8000v-universalk9.16.04.01.qcow2)
+
+Usage
+-----
+```
+docker run -d --privileged --name my-c8000v-router vr-c8000v
+```
+
+Interface mapping
+-----------------
+IOS XE 16.03.01 and 16.04.01 does only support 10 interfaces, GigabitEthernet1 is always configured
+as a management interface and then we can only use 9 interfaces for traffic. If you configure vrnetlab
+to use more then 10 the interfaces will be mapped like the table below. 
+
+The following images have been verified to NOT exhibit this behavior
+- c8000v-universalk9.03.16.02.S.155-3.S2-ext.qcow2
+- c8000v-universalk9.03.17.02.S.156-1.S2-std.qcow2
+
+| vr-c8000v | vr-xcon |
+| :---:  |  :---:  |
+| Gi2    | 10      |
+| Gi3    | 1       |
+| Gi4    | 2       |
+| Gi5    | 3       |
+| Gi6    | 4       |
+| Gi7    | 5       |
+| Gi8    | 6       |
+| Gi9    | 7       |
+| Gi10   | 8       |
+| Gi11   | 9       |
+
+System requirements
+-------------------
+CPU: 1 core
+
+RAM: 4GB
+
+Disk: <500MB
+
+License handling
+----------------
+You can feed a license file into c8000v by putting a text file containing the
+license in this directory next to your .qcow2 image. Name the license file the
+same as your .qcow2 file but append ".license", e.g. if you have
+"c8000v-universalk9.16.04.01.qcow2" you would name the license file
+"c8000v-universalk9.16.04.01.qcow2.license".
+
+The license is bound to a specific UDI and usually expires within a given time.
+To make sure that everything works out smoothly we configure the clock to
+a specific date during the installation process. This is because the license
+only has an expiration date not a start date.
+
+The license unlocks feature and throughput. The default throughput for C8000v is
+20Mbit/s which is perfectly for basic management and testing.
+
+FUAQ - Frequently or Unfrequently Asked Questions
+-------------------------------------------------
+##### Q: Has this been extensively tested?
+A: Nope. 

--- a/c8000v/docker/Dockerfile
+++ b/c8000v/docker/Dockerfile
@@ -1,0 +1,23 @@
+FROM debian:bullseye
+MAINTAINER Kristian Larsson <kristian@spritelink.net>
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -qy \
+ && apt-get upgrade -qy \
+ && apt-get install -y \
+    bridge-utils \
+    iproute2 \
+    python3-ipy \
+    socat \
+    qemu-kvm \
+    genisoimage \
+ && rm -rf /var/lib/apt/lists/*
+
+ARG IMAGE
+COPY $IMAGE* /
+COPY *.py /
+
+EXPOSE 22 161/udp 830 5000 10000-10099
+HEALTHCHECK CMD ["/healthcheck.py"]
+ENTRYPOINT ["/launch.py"]

--- a/c8000v/docker/Dockerfile
+++ b/c8000v/docker/Dockerfile
@@ -14,6 +14,8 @@ RUN apt-get update -qy \
     genisoimage \
  && rm -rf /var/lib/apt/lists/*
 
+ARG VERSION
+ENV VERSION=${VERSION}
 ARG IMAGE
 COPY $IMAGE* /
 COPY *.py /

--- a/c8000v/docker/launch.py
+++ b/c8000v/docker/launch.py
@@ -146,7 +146,10 @@ class C8000v_vm(vrnetlab.VM):
 
         self.wait_write("hostname c8000v")
         self.wait_write("username %s privilege 15 password %s" % (self.username, self.password))
-        self.wait_write("ip domain-name example.com")
+        if int(self.version.split('.')[0]) >= 16:
+           self.wait_write("ip domain name example.com")
+        else:
+           self.wait_write("ip domain-name example.com")
         self.wait_write("crypto key generate rsa modulus 2048")
 
         self.wait_write("interface GigabitEthernet1")

--- a/c8000v/docker/launch.py
+++ b/c8000v/docker/launch.py
@@ -158,14 +158,18 @@ class C8000v_vm(vrnetlab.VM):
         self.wait_write("exit")
         self.wait_write("restconf")
         self.wait_write("netconf-yang")
+        self.wait_write("netconf max-sessions 16")
+        # I did not find any documentation about this, but is seems like a good idea!?
+        self.wait_write("netconf detailed-error")
         self.wait_write("ip ssh server algorithm mac hmac-sha2-512")
+        self.wait_write("ip ssh maxstartups 128")
 
         self.wait_write("line vty 0 4")
         self.wait_write("login local")
         self.wait_write("transport input all")
         self.wait_write("end")
         self.wait_write("copy running-config startup-config")
-        self.wait_write("\r", None)
+        self.wait_write("\r", "Destination")
 
 
 class C8000v(vrnetlab.VR):

--- a/c8000v/docker/launch.py
+++ b/c8000v/docker/launch.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+
+import datetime
+import logging
+import os
+import re
+import signal
+import subprocess
+import sys
+import telnetlib
+import time
+
+import vrnetlab
+
+def handle_SIGCHLD(signal, frame):
+    os.waitpid(-1, os.WNOHANG)
+
+def handle_SIGTERM(signal, frame):
+    sys.exit(0)
+
+signal.signal(signal.SIGINT, handle_SIGTERM)
+signal.signal(signal.SIGTERM, handle_SIGTERM)
+signal.signal(signal.SIGCHLD, handle_SIGCHLD)
+
+TRACE_LEVEL_NUM = 9
+logging.addLevelName(TRACE_LEVEL_NUM, "TRACE")
+def trace(self, message, *args, **kws):
+    # Yes, logger takes its '*args' as 'args'.
+    if self.isEnabledFor(TRACE_LEVEL_NUM):
+        self._log(TRACE_LEVEL_NUM, message, args, **kws)
+logging.Logger.trace = trace
+
+
+
+class C8000v_vm(vrnetlab.VM):
+    def __init__(self, username, password, install_mode=False):
+        disk_image = None
+        for e in sorted(os.listdir("/")):
+            if not disk_image and re.search(".qcow2$", e):
+                disk_image = "/" + e
+            if re.search(r"\.license$", e):
+                os.rename("/" + e, "/tftpboot/license.lic")
+
+        self.license = False
+        if os.path.isfile("/tftpboot/license.lic"):
+            logger.info("License found")
+            self.license = True
+
+        super(C8000v_vm, self).__init__(username, password, disk_image=disk_image)
+        self.nic_type = "virtio-net-pci"
+        self.install_mode = install_mode
+        self.num_nics = 9
+
+        if self.install_mode:
+            logger.trace("install mode")
+            self.image_name = "config.iso"
+            self.create_boot_image()
+
+            self.qemu_args.extend(["-cdrom", "/" +self.image_name]) 
+
+
+    def create_boot_image(self):
+        """ Creates a iso image with a bootstrap configuration
+        """
+
+        cfg_file = open('/iosxe_config.txt', 'w')
+        if self.license:
+            cfg_file.write("do clock set 13:33:37 1 Jan 2010\r\n")
+            cfg_file.write("interface GigabitEthernet1\r\n")
+            cfg_file.write("ip address 10.0.0.15 255.255.255.0\r\n")
+            cfg_file.write("no shut\r\n")
+            cfg_file.write("exit\r\n")
+            cfg_file.write("license accept end user agreement\r\n")
+            cfg_file.write("yes\r\n")
+            cfg_file.write("do license install tftp://10.0.0.2/license.lic\r\n\r\n")
+
+        cfg_file.write("platform console serial\r\n\r\n")
+        cfg_file.write("do wr\r\n")
+        cfg_file.write("do reload\r\n")
+        cfg_file.close()
+
+        genisoimage_args = ["genisoimage", "-l", "-o", "/" + self.image_name, "/iosxe_config.txt"]
+
+        subprocess.Popen(genisoimage_args)
+
+
+    def bootstrap_spin(self):
+        """ This function should be called periodically to do work.
+        """
+
+        if self.spins > 300:
+            # too many spins with no result ->  give up
+            self.stop()
+            self.start()
+            return
+
+        (ridx, match, res) = self.tn.expect([b"Press RETURN to get started!"], 1)
+        if match: # got a match!
+            if ridx == 0: # login
+                if self.install_mode:
+                    self.wait_write("", wait=None)
+                    self.wait_write("", None)
+                    self.wait_write("enable", wait=">")
+                    self.wait_write("clear platform software vnic-if nvtable")
+                    self.wait_write("")
+                    self.running = True
+                    return
+
+                self.logger.debug("matched, Press RETURN to get started.")
+                self.wait_write("", wait=None)
+
+                # run main config!
+                self.bootstrap_config()
+                # close telnet connection
+                self.tn.close()
+                # startup time?
+                startup_time = datetime.datetime.now() - self.start_time
+                self.logger.info("Startup complete in: %s" % startup_time)
+                # mark as running
+                self.running = True
+                return
+
+        # no match, if we saw some output from the router it's probably
+        # booting, so let's give it some more time
+        if res != b'':
+            self.logger.trace("OUTPUT: %s" % res.decode())
+            # reset spins if we saw some output
+            self.spins = 0
+
+        self.spins += 1
+
+        return
+
+
+    def bootstrap_config(self):
+        """ Do the actual bootstrap config
+        """
+        self.logger.info("applying bootstrap configuration")
+
+        self.wait_write("", None)
+        self.wait_write("enable", wait=">")
+        self.wait_write("configure terminal", wait=">")
+
+        self.wait_write("hostname c8000v")
+        self.wait_write("username %s privilege 15 password %s" % (self.username, self.password))
+        self.wait_write("ip domain-name example.com")
+        self.wait_write("crypto key generate rsa modulus 2048")
+
+        self.wait_write("interface GigabitEthernet1")
+        self.wait_write("ip address 10.0.0.15 255.255.255.0")
+        self.wait_write("no shut")
+        self.wait_write("exit")
+        self.wait_write("restconf")
+        self.wait_write("netconf-yang")
+
+        self.wait_write("line vty 0 4")
+        self.wait_write("login local")
+        self.wait_write("transport input all")
+        self.wait_write("end")
+        self.wait_write("copy running-config startup-config")
+        self.wait_write("\r", None)
+
+
+class C8000v(vrnetlab.VR):
+    def __init__(self, username, password):
+        super(C8000v, self).__init__(username, password)
+        self.vms = [ C8000v_vm(username, password) ]
+
+
+class C8000v_installer(C8000v):
+    """ C8000v installer
+        
+        Will start the C8000v with a mounted iso to make sure that we get
+        console output on serial, not vga.
+    """
+    def __init__(self, username, password):
+        super(C8000v, self).__init__(username, password)
+        self.vms = [ C8000v_vm(username, password, install_mode=True)  ]
+
+    def install(self):
+        self.logger.info("Installing C8000v")
+        csr = self.vms[0]
+        while not csr.running:
+            csr.work()
+        time.sleep(30)
+        csr.stop()
+        self.logger.info("Installation complete")
+
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser(description='')
+    parser.add_argument('--trace', action='store_true', help='enable trace level logging')
+    parser.add_argument('--username', default='vrnetlab', help='Username')
+    parser.add_argument('--password', default='VR-netlab9', help='Password')
+    parser.add_argument('--install', action='store_true', help='Install C8000v')
+    args = parser.parse_args()
+
+    LOG_FORMAT = "%(asctime)s: %(module)-10s %(levelname)-8s %(message)s"
+    logging.basicConfig(format=LOG_FORMAT)
+    logger = logging.getLogger()
+
+    logger.setLevel(logging.DEBUG)
+    if args.trace:
+        logger.setLevel(1)
+
+    if args.install:
+        vr = C8000v_installer(args.username, args.password)
+        vr.install()
+    else:
+        vr = C8000v(args.username, args.password)
+        vr.start()

--- a/c8000v/docker/launch.py
+++ b/c8000v/docker/launch.py
@@ -73,7 +73,7 @@ class C8000v_vm(vrnetlab.VM):
             cfg_file.write("license accept end user agreement\r\n")
             cfg_file.write("yes\r\n")
             cfg_file.write("do license install tftp://10.0.0.2/license.lic\r\n\r\n")
-
+        cfg_file.write("license boot level network-premier addon dna-premier\r\n")
         cfg_file.write("platform console serial\r\n\r\n")
         cfg_file.write("do wr\r\n")
         cfg_file.write("do reload\r\n")
@@ -152,6 +152,7 @@ class C8000v_vm(vrnetlab.VM):
         self.wait_write("exit")
         self.wait_write("restconf")
         self.wait_write("netconf-yang")
+        self.wait_write("ip ssh server algorithm mac hmac-sha2-512")
 
         self.wait_write("line vty 0 4")
         self.wait_write("login local")

--- a/c8000v/docker/launch.py
+++ b/c8000v/docker/launch.py
@@ -47,7 +47,7 @@ class C8000v_vm(vrnetlab.VM):
             self.license = True
 
         super(C8000v_vm, self).__init__(username, password, disk_image=disk_image)
-        self.nic_type = "virtio-net-pci"
+        self.nic_type = "vmxnet3"
         self.install_mode = install_mode
         self.num_nics = 9
 

--- a/topology-machine/topomachine
+++ b/topology-machine/topomachine
@@ -24,7 +24,7 @@ class VrTopo:
         for r, val in self.routers.items():
             if 'type' not in val:
                 raise ValueError("'type' is not defined for router %s" % r)
-            if val['type'] not in ('dummy', 'xcon', 'bgp', 'xrv', 'xrv9k', 'vmx', 'sros', 'csr', 'nxos', 'nxos9kv', 'ucpe-oneos', 'vqfx', 'vrp', 'veos', 'openwrt'):
+            if val['type'] not in ('dummy', 'xcon', 'bgp', 'xrv', 'xrv9k', 'vmx', 'sros', 'csr', 'c8000v', 'nxos', 'nxos9kv', 'ucpe-oneos', 'vqfx', 'vrp', 'veos', 'openwrt'):
                 raise ValueError("Unknown type %s for router %s" % (val['type'], r))
 
         # preserve order of entries if keep_order is set
@@ -153,7 +153,7 @@ class VrTopo:
             return "{}/1/{}".format(1+int((interface-1)/6), 1+(interface-1)%6)
         elif r['type'] == 'bgp':
             return "tap%d" % (interface-1)
-        elif r['type'] == 'csr':
+        elif r['type'] == 'csr' or r['type'] == 'c8000v':
             return "GigabitEthernet%d" % (interface+1)
         elif r['type'] == 'ucpe-oneos':
             return "eth%d" % (interface)


### PR DESCRIPTION
This started of as a copy of the (now legacy) `csr` platform, but has since been improved to:
- handle minor differences / new config defaults in the bootstrap script,
- use vmxnet3 NIC type because that is the only where dot1q VLAN tagged frame processing works,
- make the install phase more robust.

Naming things is hard. I initially used `cat8000v` when I started, but now I see the more established name is `c8000v`. Un-🐈‍⬛ before merge? 