### PR TITLE
Basic smoke test for SSH management connectivity

### DIFF
--- a/ci-builder-image/Dockerfile
+++ b/ci-builder-image/Dockerfile
@@ -5,6 +5,8 @@ RUN apt-get update \
     curl \
 	docker.io \
 	make \
+	ripgrep \
+	sshpass \
  && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash \
  && apt-get install -y git-lfs \
  && rm -rf /var/lib/apt/lists/*

--- a/makefile.include
+++ b/makefile.include
@@ -62,12 +62,20 @@ docker-test:
 		$(MAKE) IMAGE=$$IMAGE docker-test-image; \
 	done
 
-CNT_PREFIX ?= $(PNS)-test-image-$(VR_NAME)
+CNT_PREFIX ?= $(PNS)-test-image-$(VR_NAME)-$(VERSION)
 TEST_TIMEOUT ?= 2400
 
-docker-test-image: CONTAINER_NAME?=$(CNT_PREFIX)-$(VERSION)
+docker-test-image: CONTAINER_NAME?=$(CNT_PREFIX)-dut
 docker-test-image:
-	../test/test-image $(TAG_NAME) $(CONTAINER_NAME) $$TEST_PARAMS
+# Run the test script in a container to ensure:
+# 1. we have all the tooling available,
+# 2. the test container and the device under test container end up in the same network.
+# We attach the hosts docker socket to allow creating new containers, but cannot
+# bind mount the working directory from a sibling container ..
+	-docker rm -f $(CNT_PREFIX)
+	docker create -t --name $(CNT_PREFIX) -v /var/run/docker.sock:/var/run/docker.sock vrnetlab/ci-builder /test-image -t $(TEST_TIMEOUT) $(TAG_NAME) $(CONTAINER_NAME) $(TEST_PARAMS)
+	docker cp $(CURDIR)/../test/test-image $(CNT_PREFIX):/
+	docker start --attach $(CNT_PREFIX)
 
 docker-test-clean:
 	docker ps -aqf name=$(CNT_PREFIX) | xargs --no-run-if-empty docker rm -f

--- a/test/test-image
+++ b/test/test-image
@@ -55,6 +55,29 @@ echo "\n"
 if [ $health = "healthy" ]
 then
   echo -e "\e[32m$name became healthy in $SECONDS seconds\e[0m"
+  container_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$name")
+
+  if [ -z "$container_ip" ]; then
+    echo "Error: Unable to retrieve container IP address."
+    exit 1
+  fi
+
+  echo "Container IP address: $container_ip"
+
+  ssh_user="vrnetlab"
+  ssh_password="VR-netlab9"
+
+  # Test SSH connection using sshpass. We run the "exit" command, but since not
+  # all platforms support it, we instead check whether an interactive session
+  # was started by checking the output for the string "Entering interactive session"
+  sshpass -v -p "$ssh_password" ssh -v -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$ssh_user@$container_ip" exit 2>&1 | rg --passthru "Entering interactive session"
+
+  if [ $? -eq 0 ]; then
+    echo "SSH connection test passed."
+  else
+    echo "SSH connection test failed."
+    exit 1
+  fi
   docker stop $name
 else
   echo -e "\e[31m$name failed to become healthy after $SECONDS seconds\e[0m"


### PR DESCRIPTION
Just make sure at least _something_ is listening on the management interface. Not the full implementation as proposed in #53, but it's better than nothing 😄

I will update the `vrnetlab/ci-builder` image in docker hub too.