### PR TITLE
Build (with) topomachine container in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,28 @@ jobs:
         if: always()
         run: make -C vr-bgp docker-test-clean
 
+  test-topomachine:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build topomachine
+        run: |
+          make topology-machine
+
+      - name: Test topomachine
+        run: |
+          make topology-machine-test
+
+      - name: Save topomachine logs
+        if: always()
+        run: |
+          make -C topology-machine docker-test-save-logs
+
+      - name: Clean test topomachine containers
+        if: always()
+        run: make -C topology-machine docker-test-clean
+
   test-vr:
     runs-on: ["self-hosted"]
     container:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,6 +49,9 @@ vr-xcon:
 vr-bgp:
   <<: *build-template
 
+topology-machine:
+  extends: .build
+
 csr:
   <<: *build-template
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IMAGES_DIR=
-VRS = vr-xcon vr-bgp csr nxos nxos9kv routeros sros veos vmx vsr1000 vqfx vrp xrv xrv9k
+VRS = vr-xcon vr-bgp topology-machine csr nxos nxos9kv routeros sros veos vmx vsr1000 vqfx vrp xrv xrv9k
 VRS_PUSH = $(VRS:=-push)
 VRS_TEST = $(VRS:=-test)
 

--- a/topology-machine/Dockerfile
+++ b/topology-machine/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update -qy \
  && apt-get -y install docker-ce \
  && rm -rf /var/lib/apt/lists/*
 
-ADD topomachine /
-ADD *example* /
+ADD topomachine /usr/local/bin
+ADD *example* /data/
 
-ENTRYPOINT ["/topomachine"]
+ENTRYPOINT ["/usr/local/bin/topomachine"]

--- a/topology-machine/Dockerfile
+++ b/topology-machine/Dockerfile
@@ -13,6 +13,9 @@ RUN apt-get update -qy \
     curl \
     gnupg2 \
     software-properties-common \
+# Install git & make so that we can use topomachine in CI to check for uncommitted topology and scripts changes
+    git \
+    make \
  && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
  && add-apt-repository \
    "deb [arch=amd64] https://download.docker.com/linux/debian \

--- a/topology-machine/Dockerfile
+++ b/topology-machine/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:bookworm
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -8,24 +8,22 @@ RUN apt-get update -qy \
  && apt-get install -y \
     python3-jinja2 \
     python3-yaml \
-    apt-transport-https \
-    ca-certificates \
     curl \
-    gnupg2 \
-    software-properties-common \
 # Install git & make so that we can use topomachine in CI to check for uncommitted topology and scripts changes
     git \
     make \
- && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
- && add-apt-repository \
-   "deb [arch=amd64] https://download.docker.com/linux/debian \
-   $(lsb_release -cs) \
-   stable" \
- && apt-get update -qy \
+ && install -m 0755 -d /etc/apt/keyrings \
+ && curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc \
+ && chmod a+r /etc/apt/keyrings/docker.asc \
+ && echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null \
+ && apt-get update \
  && apt-get -y install docker-ce \
  && rm -rf /var/lib/apt/lists/*
 
 ADD topomachine /usr/local/bin
 ADD *example* /data/
 
+WORKDIR /data
 ENTRYPOINT ["/usr/local/bin/topomachine"]

--- a/topology-machine/Dockerfile
+++ b/topology-machine/Dockerfile
@@ -23,7 +23,6 @@ RUN apt-get update -qy \
  && rm -rf /var/lib/apt/lists/*
 
 ADD topomachine /usr/local/bin
-ADD *example* /data/
 
 WORKDIR /data
 ENTRYPOINT ["/usr/local/bin/topomachine"]

--- a/topology-machine/Makefile
+++ b/topology-machine/Makefile
@@ -6,13 +6,28 @@ all:
 docker-push:
 	docker push $(REGISTRY)topomachine
 
+ifeq ($(PNS),)
+PNS:=$(shell whoami | sed 's/[^[:alnum:]._-]\+/_/g')
+endif
+CNT_PREFIX?=$(PNS)-topomachine
+VOLUME_NAME?=$(CNT_PREFIX)-data
+
 docker-test:
-	docker run --rm $(REGISTRY)topomachine --build example-hltopo.json
-	docker run --rm $(REGISTRY)topomachine --run example-lltopo.json --dry-run
-	docker run --rm $(REGISTRY)topomachine --template example-lltopo.json example.template
+# Do the (awkward) volume-copy dance to make sure we can run this test in GitLab
+# CI where the test script runs in a container with the hosts
+# /var/run/docker.sock mounted - sibling container.
+	-docker rm -f $(CNT_PREFIX)
+	-docker volume rm $(VOLUME_NAME)
+	docker volume create $(VOLUME_NAME)
+	docker create -v $(VOLUME_NAME):/data --name $(CNT_PREFIX) busybox
+	for f in example*; do docker cp $$f $(CNT_PREFIX):/data; done
+	docker rm $(CNT_PREFIX)
+	docker run -v $(VOLUME_NAME):/data --rm $(REGISTRY)topomachine --build example-hltopo.json
+	docker run -v $(VOLUME_NAME):/data --rm $(REGISTRY)topomachine --run example-lltopo.json --dry-run
+	docker run -v $(VOLUME_NAME):/data --rm $(REGISTRY)topomachine --template example-lltopo.json example.template
 
 docker-test-clean:
-# nothing to do
+	docker volume rm $(VOLUME_NAME)
 
 docker-test-save-logs:
 # nothing to do

--- a/topology-machine/Makefile
+++ b/topology-machine/Makefile
@@ -5,3 +5,14 @@ all:
 
 docker-push:
 	docker push $(REGISTRY)topomachine
+
+docker-test:
+	docker run --rm $(REGISTRY)topomachine --build example-hltopo.json
+	docker run --rm $(REGISTRY)topomachine --run example-lltopo.json --dry-run
+	docker run --rm $(REGISTRY)topomachine --template example-lltopo.json example.template
+
+docker-test-clean:
+# nothing to do
+
+docker-test-save-logs:
+# nothing to do

--- a/topology-machine/README.md
+++ b/topology-machine/README.md
@@ -177,16 +177,21 @@ The topomachine docker container can be used to generate the low level topology
 topology (--run), and to generate custom output using a jinja2 template 
 (--template).
 
+The topomachine binary is placed in `/usr/local/bin/topomachine` and is also set
+as an *ENTRYPOINT* for the container. The *WORKDIR* is set to `/data` so you can
+bind mount a host directory to `/data` and use `docker run ...` as a drop-in
+replacement for the topomachine command.
+
 For example:
 
 generate the low level topology:
 ```
-$ docker run -t -v $(pwd):/data topomachine --build /data/example-hltopo.json > example-lltopo.json
+$ docker run -t -v $(pwd):/data topomachine --build example-hltopo.json > example-lltopo.json
 ```
 
 generate the docker run commands:
 ```
-$ docker run -v $(pwd):/data topomachine --run /data/example-lltopo.json --dry-run
+$ docker run -v $(pwd):/data topomachine --run example-lltopo.json --dry-run
 The following commands would be executed:
 docker run --privileged -d --name ams-core-1 vrnetlab/vr-xrv:5.1.1.54U --foo bar 1
 docker run --privileged -d --name ams-core-2 vrnetlab/vr-xrv:5.1.1.54U --foo bar 1
@@ -204,14 +209,15 @@ docker run --rm --privileged -d --name vr-xcon --link ams-core-1:ams-core-1 --li
 docker run --privileged -d --name vr-xcon-hub-ams-mgmt --link ams-core-1:ams-core-1 --link ams-core-2:ams-core-2 --link ams-edge-1:ams-edge-1 --link fra-core-1:fra-core-1 --link fra-core-2:fra-core-2 --link fra-edge-1:fra-edge-1 --link kul-core-1:kul-core-1 --link par-core-1:par-core-1 --link par-core-2:par-core-2 --link par-edge-1:par-edge-1 --link png-edge-1:png-edge-1 --link sgp-core-1:sgp-core-1 vrnetlab/vr-xcon --hub ams-core-1/7 ams-core-2/7 ams-edge-1/3
 ```
 
-start the topology:
+To start the topology, topomachine needs access to the docker socket. Add the
+`-v /var/run/docker.sock:/var/run/docker.sock` option to the `docker run ...`:
 ```
-$ docker run -v $(pwd):/data -v /var/run/docker.sock:/var/run/docker.sock topomachine --run /data/example-lltopo.json
+$ docker run -v $(pwd):/data -v /var/run/docker.sock:/var/run/docker.sock topomachine --run example-lltopo.json
 ```
 
 generate custom output using a jinja2 template:
 ```
-$ docker run -t -v $(pwd):/data topomachine --template /data/example-lltopo.json /data/example.template
+$ docker run -t -v $(pwd):/data topomachine --template example-lltopo.json example.template
 infrastructure {
     base-config fra-edge-1 {
         numeric-id 101;

--- a/topology-machine/example-lltopo.json
+++ b/topology-machine/example-lltopo.json
@@ -1,0 +1,990 @@
+{
+    "hubs": {
+        "ams-mgmt": [
+            {
+                "interface": "GigabitEthernet0/0/0/6",
+                "numeric": 7,
+                "router": "ams-core-1"
+            },
+            {
+                "interface": "GigabitEthernet0/0/0/6",
+                "numeric": 7,
+                "router": "ams-core-2"
+            },
+            {
+                "interface": "GigabitEthernet0/0/0/2",
+                "numeric": 3,
+                "router": "ams-edge-1"
+            }
+        ]
+    },
+    "links": [
+        {
+            "left": {
+                "interface": "GigabitEthernet0/0/0/0",
+                "numeric": 1,
+                "router": "ams-edge-1"
+            },
+            "right": {
+                "interface": "GigabitEthernet0/0/0/0",
+                "numeric": 1,
+                "router": "ams-core-1"
+            }
+        },
+        {
+            "left": {
+                "interface": "GigabitEthernet0/0/0/1",
+                "numeric": 2,
+                "router": "ams-edge-1"
+            },
+            "right": {
+                "interface": "GigabitEthernet0/0/0/0",
+                "numeric": 1,
+                "router": "ams-core-2"
+            }
+        },
+        {
+            "left": {
+                "interface": "ge-0/0/0",
+                "numeric": 1,
+                "router": "fra-core-2"
+            },
+            "right": {
+                "interface": "GigabitEthernet0/0/0/0",
+                "numeric": 1,
+                "router": "sgp-core-1"
+            }
+        },
+        {
+            "left": {
+                "interface": "ge-0/0/1",
+                "numeric": 2,
+                "router": "fra-core-2"
+            },
+            "right": {
+                "interface": "GigabitEthernet0/0/0/0",
+                "numeric": 1,
+                "router": "kul-core-1"
+            }
+        },
+        {
+            "left": {
+                "interface": "ge-0/0/0",
+                "numeric": 1,
+                "router": "fra-edge-1"
+            },
+            "right": {
+                "interface": "ge-0/0/0",
+                "numeric": 1,
+                "router": "fra-core-1"
+            }
+        },
+        {
+            "left": {
+                "interface": "ge-0/0/1",
+                "numeric": 2,
+                "router": "fra-edge-1"
+            },
+            "right": {
+                "interface": "ge-0/0/2",
+                "numeric": 3,
+                "router": "fra-core-2"
+            }
+        },
+        {
+            "left": {
+                "interface": "1/1/1",
+                "numeric": 1,
+                "router": "par-core-1"
+            },
+            "right": {
+                "interface": "GigabitEthernet0/0/0/1",
+                "numeric": 2,
+                "router": "sgp-core-1"
+            }
+        },
+        {
+            "left": {
+                "interface": "1/1/2",
+                "numeric": 2,
+                "router": "par-core-1"
+            },
+            "right": {
+                "interface": "GigabitEthernet0/0/0/1",
+                "numeric": 2,
+                "router": "kul-core-1"
+            }
+        },
+        {
+            "left": {
+                "interface": "1/1/1",
+                "numeric": 1,
+                "router": "par-edge-1"
+            },
+            "right": {
+                "interface": "1/1/3",
+                "numeric": 3,
+                "router": "par-core-1"
+            }
+        },
+        {
+            "left": {
+                "interface": "1/1/2",
+                "numeric": 2,
+                "router": "par-edge-1"
+            },
+            "right": {
+                "interface": "1/1/1",
+                "numeric": 1,
+                "router": "par-core-2"
+            }
+        },
+        {
+            "left": {
+                "interface": "GigabitEthernet0/0/0/0",
+                "numeric": 1,
+                "router": "png-edge-1"
+            },
+            "right": {
+                "interface": "GigabitEthernet0/0/0/2",
+                "numeric": 3,
+                "router": "sgp-core-1"
+            }
+        },
+        {
+            "left": {
+                "interface": "GigabitEthernet0/0/0/1",
+                "numeric": 2,
+                "router": "png-edge-1"
+            },
+            "right": {
+                "interface": "GigabitEthernet0/0/0/2",
+                "numeric": 3,
+                "router": "kul-core-1"
+            }
+        },
+        {
+            "left": {
+                "interface": "GigabitEthernet0/0/0/3",
+                "numeric": 4,
+                "router": "kul-core-1"
+            },
+            "right": {
+                "interface": "GigabitEthernet0/0/0/3",
+                "numeric": 4,
+                "router": "sgp-core-1"
+            }
+        },
+        {
+            "left": {
+                "interface": "GigabitEthernet0/0/0/1",
+                "numeric": 2,
+                "router": "ams-core-1"
+            },
+            "right": {
+                "interface": "GigabitEthernet0/0/0/1",
+                "numeric": 2,
+                "router": "ams-core-2"
+            }
+        },
+        {
+            "left": {
+                "interface": "GigabitEthernet0/0/0/2",
+                "numeric": 3,
+                "router": "ams-core-1"
+            },
+            "right": {
+                "interface": "ge-0/0/1",
+                "numeric": 2,
+                "router": "fra-core-1"
+            }
+        },
+        {
+            "left": {
+                "interface": "GigabitEthernet0/0/0/3",
+                "numeric": 4,
+                "router": "ams-core-1"
+            },
+            "right": {
+                "interface": "ge-0/0/3",
+                "numeric": 4,
+                "router": "fra-core-2"
+            }
+        },
+        {
+            "left": {
+                "interface": "GigabitEthernet0/0/0/4",
+                "numeric": 5,
+                "router": "ams-core-1"
+            },
+            "right": {
+                "interface": "1/1/4",
+                "numeric": 4,
+                "router": "par-core-1"
+            }
+        },
+        {
+            "left": {
+                "interface": "GigabitEthernet0/0/0/5",
+                "numeric": 6,
+                "router": "ams-core-1"
+            },
+            "right": {
+                "interface": "1/1/2",
+                "numeric": 2,
+                "router": "par-core-2"
+            }
+        },
+        {
+            "left": {
+                "interface": "GigabitEthernet0/0/0/2",
+                "numeric": 3,
+                "router": "ams-core-2"
+            },
+            "right": {
+                "interface": "ge-0/0/2",
+                "numeric": 3,
+                "router": "fra-core-1"
+            }
+        },
+        {
+            "left": {
+                "interface": "GigabitEthernet0/0/0/3",
+                "numeric": 4,
+                "router": "ams-core-2"
+            },
+            "right": {
+                "interface": "ge-0/0/4",
+                "numeric": 5,
+                "router": "fra-core-2"
+            }
+        },
+        {
+            "left": {
+                "interface": "GigabitEthernet0/0/0/4",
+                "numeric": 5,
+                "router": "ams-core-2"
+            },
+            "right": {
+                "interface": "1/1/5",
+                "numeric": 5,
+                "router": "par-core-1"
+            }
+        },
+        {
+            "left": {
+                "interface": "GigabitEthernet0/0/0/5",
+                "numeric": 6,
+                "router": "ams-core-2"
+            },
+            "right": {
+                "interface": "1/1/3",
+                "numeric": 3,
+                "router": "par-core-2"
+            }
+        },
+        {
+            "left": {
+                "interface": "ge-0/0/3",
+                "numeric": 4,
+                "router": "fra-core-1"
+            },
+            "right": {
+                "interface": "ge-0/0/5",
+                "numeric": 6,
+                "router": "fra-core-2"
+            }
+        },
+        {
+            "left": {
+                "interface": "ge-0/0/4",
+                "numeric": 5,
+                "router": "fra-core-1"
+            },
+            "right": {
+                "interface": "1/1/6",
+                "numeric": 6,
+                "router": "par-core-1"
+            }
+        },
+        {
+            "left": {
+                "interface": "ge-0/0/5",
+                "numeric": 6,
+                "router": "fra-core-1"
+            },
+            "right": {
+                "interface": "1/1/4",
+                "numeric": 4,
+                "router": "par-core-2"
+            }
+        },
+        {
+            "left": {
+                "interface": "ge-0/0/6",
+                "numeric": 7,
+                "router": "fra-core-2"
+            },
+            "right": {
+                "interface": "2/1/1",
+                "numeric": 7,
+                "router": "par-core-1"
+            }
+        },
+        {
+            "left": {
+                "interface": "ge-0/0/7",
+                "numeric": 8,
+                "router": "fra-core-2"
+            },
+            "right": {
+                "interface": "1/1/5",
+                "numeric": 5,
+                "router": "par-core-2"
+            }
+        },
+        {
+            "left": {
+                "interface": "2/1/2",
+                "numeric": 8,
+                "router": "par-core-1"
+            },
+            "right": {
+                "interface": "1/1/6",
+                "numeric": 6,
+                "router": "par-core-2"
+            }
+        }
+    ],
+    "links_by_nodes": {
+        "ams-core-1": {
+            "ams-core-2": [
+                {
+                    "our_interface": "GigabitEthernet0/0/0/1",
+                    "our_numeric": 2,
+                    "their_interface": "GigabitEthernet0/0/0/1",
+                    "their_numeric": 2
+                }
+            ],
+            "ams-edge-1": [
+                {
+                    "our_interface": "GigabitEthernet0/0/0/0",
+                    "our_numeric": 1,
+                    "their_interface": "GigabitEthernet0/0/0/0",
+                    "their_numeric": 1
+                }
+            ],
+            "fra-core-1": [
+                {
+                    "our_interface": "GigabitEthernet0/0/0/2",
+                    "our_numeric": 3,
+                    "their_interface": "ge-0/0/1",
+                    "their_numeric": 2
+                }
+            ],
+            "fra-core-2": [
+                {
+                    "our_interface": "GigabitEthernet0/0/0/3",
+                    "our_numeric": 4,
+                    "their_interface": "ge-0/0/3",
+                    "their_numeric": 4
+                }
+            ],
+            "par-core-1": [
+                {
+                    "our_interface": "GigabitEthernet0/0/0/4",
+                    "our_numeric": 5,
+                    "their_interface": "1/1/4",
+                    "their_numeric": 4
+                }
+            ],
+            "par-core-2": [
+                {
+                    "our_interface": "GigabitEthernet0/0/0/5",
+                    "our_numeric": 6,
+                    "their_interface": "1/1/2",
+                    "their_numeric": 2
+                }
+            ]
+        },
+        "ams-core-2": {
+            "ams-core-1": [
+                {
+                    "our_interface": "GigabitEthernet0/0/0/1",
+                    "our_numeric": 2,
+                    "their_interface": "GigabitEthernet0/0/0/1",
+                    "their_numeric": 2
+                }
+            ],
+            "ams-edge-1": [
+                {
+                    "our_interface": "GigabitEthernet0/0/0/0",
+                    "our_numeric": 1,
+                    "their_interface": "GigabitEthernet0/0/0/1",
+                    "their_numeric": 2
+                }
+            ],
+            "fra-core-1": [
+                {
+                    "our_interface": "GigabitEthernet0/0/0/2",
+                    "our_numeric": 3,
+                    "their_interface": "ge-0/0/2",
+                    "their_numeric": 3
+                }
+            ],
+            "fra-core-2": [
+                {
+                    "our_interface": "GigabitEthernet0/0/0/3",
+                    "our_numeric": 4,
+                    "their_interface": "ge-0/0/4",
+                    "their_numeric": 5
+                }
+            ],
+            "par-core-1": [
+                {
+                    "our_interface": "GigabitEthernet0/0/0/4",
+                    "our_numeric": 5,
+                    "their_interface": "1/1/5",
+                    "their_numeric": 5
+                }
+            ],
+            "par-core-2": [
+                {
+                    "our_interface": "GigabitEthernet0/0/0/5",
+                    "our_numeric": 6,
+                    "their_interface": "1/1/3",
+                    "their_numeric": 3
+                }
+            ]
+        },
+        "ams-edge-1": {
+            "ams-core-1": [
+                {
+                    "our_interface": "GigabitEthernet0/0/0/0",
+                    "our_numeric": 1,
+                    "their_interface": "GigabitEthernet0/0/0/0",
+                    "their_numeric": 1
+                }
+            ],
+            "ams-core-2": [
+                {
+                    "our_interface": "GigabitEthernet0/0/0/1",
+                    "our_numeric": 2,
+                    "their_interface": "GigabitEthernet0/0/0/0",
+                    "their_numeric": 1
+                }
+            ]
+        },
+        "fra-core-1": {
+            "ams-core-1": [
+                {
+                    "our_interface": "ge-0/0/1",
+                    "our_numeric": 2,
+                    "their_interface": "GigabitEthernet0/0/0/2",
+                    "their_numeric": 3
+                }
+            ],
+            "ams-core-2": [
+                {
+                    "our_interface": "ge-0/0/2",
+                    "our_numeric": 3,
+                    "their_interface": "GigabitEthernet0/0/0/2",
+                    "their_numeric": 3
+                }
+            ],
+            "fra-core-2": [
+                {
+                    "our_interface": "ge-0/0/3",
+                    "our_numeric": 4,
+                    "their_interface": "ge-0/0/5",
+                    "their_numeric": 6
+                }
+            ],
+            "fra-edge-1": [
+                {
+                    "our_interface": "ge-0/0/0",
+                    "our_numeric": 1,
+                    "their_interface": "ge-0/0/0",
+                    "their_numeric": 1
+                }
+            ],
+            "par-core-1": [
+                {
+                    "our_interface": "ge-0/0/4",
+                    "our_numeric": 5,
+                    "their_interface": "1/1/6",
+                    "their_numeric": 6
+                }
+            ],
+            "par-core-2": [
+                {
+                    "our_interface": "ge-0/0/5",
+                    "our_numeric": 6,
+                    "their_interface": "1/1/4",
+                    "their_numeric": 4
+                }
+            ]
+        },
+        "fra-core-2": {
+            "ams-core-1": [
+                {
+                    "our_interface": "ge-0/0/3",
+                    "our_numeric": 4,
+                    "their_interface": "GigabitEthernet0/0/0/3",
+                    "their_numeric": 4
+                }
+            ],
+            "ams-core-2": [
+                {
+                    "our_interface": "ge-0/0/4",
+                    "our_numeric": 5,
+                    "their_interface": "GigabitEthernet0/0/0/3",
+                    "their_numeric": 4
+                }
+            ],
+            "fra-core-1": [
+                {
+                    "our_interface": "ge-0/0/5",
+                    "our_numeric": 6,
+                    "their_interface": "ge-0/0/3",
+                    "their_numeric": 4
+                }
+            ],
+            "fra-edge-1": [
+                {
+                    "our_interface": "ge-0/0/2",
+                    "our_numeric": 3,
+                    "their_interface": "ge-0/0/1",
+                    "their_numeric": 2
+                }
+            ],
+            "kul-core-1": [
+                {
+                    "our_interface": "ge-0/0/1",
+                    "our_numeric": 2,
+                    "their_interface": "GigabitEthernet0/0/0/0",
+                    "their_numeric": 1
+                }
+            ],
+            "par-core-1": [
+                {
+                    "our_interface": "ge-0/0/6",
+                    "our_numeric": 7,
+                    "their_interface": "2/1/1",
+                    "their_numeric": 7
+                }
+            ],
+            "par-core-2": [
+                {
+                    "our_interface": "ge-0/0/7",
+                    "our_numeric": 8,
+                    "their_interface": "1/1/5",
+                    "their_numeric": 5
+                }
+            ],
+            "sgp-core-1": [
+                {
+                    "our_interface": "ge-0/0/0",
+                    "our_numeric": 1,
+                    "their_interface": "GigabitEthernet0/0/0/0",
+                    "their_numeric": 1
+                }
+            ]
+        },
+        "fra-edge-1": {
+            "fra-core-1": [
+                {
+                    "our_interface": "ge-0/0/0",
+                    "our_numeric": 1,
+                    "their_interface": "ge-0/0/0",
+                    "their_numeric": 1
+                }
+            ],
+            "fra-core-2": [
+                {
+                    "our_interface": "ge-0/0/1",
+                    "our_numeric": 2,
+                    "their_interface": "ge-0/0/2",
+                    "their_numeric": 3
+                }
+            ]
+        },
+        "kul-core-1": {
+            "fra-core-2": [
+                {
+                    "our_interface": "GigabitEthernet0/0/0/0",
+                    "our_numeric": 1,
+                    "their_interface": "ge-0/0/1",
+                    "their_numeric": 2
+                }
+            ],
+            "par-core-1": [
+                {
+                    "our_interface": "GigabitEthernet0/0/0/1",
+                    "our_numeric": 2,
+                    "their_interface": "1/1/2",
+                    "their_numeric": 2
+                }
+            ],
+            "png-edge-1": [
+                {
+                    "our_interface": "GigabitEthernet0/0/0/2",
+                    "our_numeric": 3,
+                    "their_interface": "GigabitEthernet0/0/0/1",
+                    "their_numeric": 2
+                }
+            ],
+            "sgp-core-1": [
+                {
+                    "our_interface": "GigabitEthernet0/0/0/3",
+                    "our_numeric": 4,
+                    "their_interface": "GigabitEthernet0/0/0/3",
+                    "their_numeric": 4
+                }
+            ]
+        },
+        "par-core-1": {
+            "ams-core-1": [
+                {
+                    "our_interface": "1/1/4",
+                    "our_numeric": 4,
+                    "their_interface": "GigabitEthernet0/0/0/4",
+                    "their_numeric": 5
+                }
+            ],
+            "ams-core-2": [
+                {
+                    "our_interface": "1/1/5",
+                    "our_numeric": 5,
+                    "their_interface": "GigabitEthernet0/0/0/4",
+                    "their_numeric": 5
+                }
+            ],
+            "fra-core-1": [
+                {
+                    "our_interface": "1/1/6",
+                    "our_numeric": 6,
+                    "their_interface": "ge-0/0/4",
+                    "their_numeric": 5
+                }
+            ],
+            "fra-core-2": [
+                {
+                    "our_interface": "2/1/1",
+                    "our_numeric": 7,
+                    "their_interface": "ge-0/0/6",
+                    "their_numeric": 7
+                }
+            ],
+            "kul-core-1": [
+                {
+                    "our_interface": "1/1/2",
+                    "our_numeric": 2,
+                    "their_interface": "GigabitEthernet0/0/0/1",
+                    "their_numeric": 2
+                }
+            ],
+            "par-core-2": [
+                {
+                    "our_interface": "2/1/2",
+                    "our_numeric": 8,
+                    "their_interface": "1/1/6",
+                    "their_numeric": 6
+                }
+            ],
+            "par-edge-1": [
+                {
+                    "our_interface": "1/1/3",
+                    "our_numeric": 3,
+                    "their_interface": "1/1/1",
+                    "their_numeric": 1
+                }
+            ],
+            "sgp-core-1": [
+                {
+                    "our_interface": "1/1/1",
+                    "our_numeric": 1,
+                    "their_interface": "GigabitEthernet0/0/0/1",
+                    "their_numeric": 2
+                }
+            ]
+        },
+        "par-core-2": {
+            "ams-core-1": [
+                {
+                    "our_interface": "1/1/2",
+                    "our_numeric": 2,
+                    "their_interface": "GigabitEthernet0/0/0/5",
+                    "their_numeric": 6
+                }
+            ],
+            "ams-core-2": [
+                {
+                    "our_interface": "1/1/3",
+                    "our_numeric": 3,
+                    "their_interface": "GigabitEthernet0/0/0/5",
+                    "their_numeric": 6
+                }
+            ],
+            "fra-core-1": [
+                {
+                    "our_interface": "1/1/4",
+                    "our_numeric": 4,
+                    "their_interface": "ge-0/0/5",
+                    "their_numeric": 6
+                }
+            ],
+            "fra-core-2": [
+                {
+                    "our_interface": "1/1/5",
+                    "our_numeric": 5,
+                    "their_interface": "ge-0/0/7",
+                    "their_numeric": 8
+                }
+            ],
+            "par-core-1": [
+                {
+                    "our_interface": "1/1/6",
+                    "our_numeric": 6,
+                    "their_interface": "2/1/2",
+                    "their_numeric": 8
+                }
+            ],
+            "par-edge-1": [
+                {
+                    "our_interface": "1/1/1",
+                    "our_numeric": 1,
+                    "their_interface": "1/1/2",
+                    "their_numeric": 2
+                }
+            ]
+        },
+        "par-edge-1": {
+            "par-core-1": [
+                {
+                    "our_interface": "1/1/1",
+                    "our_numeric": 1,
+                    "their_interface": "1/1/3",
+                    "their_numeric": 3
+                }
+            ],
+            "par-core-2": [
+                {
+                    "our_interface": "1/1/2",
+                    "our_numeric": 2,
+                    "their_interface": "1/1/1",
+                    "their_numeric": 1
+                }
+            ]
+        },
+        "png-edge-1": {
+            "kul-core-1": [
+                {
+                    "our_interface": "GigabitEthernet0/0/0/1",
+                    "our_numeric": 2,
+                    "their_interface": "GigabitEthernet0/0/0/2",
+                    "their_numeric": 3
+                }
+            ],
+            "sgp-core-1": [
+                {
+                    "our_interface": "GigabitEthernet0/0/0/0",
+                    "our_numeric": 1,
+                    "their_interface": "GigabitEthernet0/0/0/2",
+                    "their_numeric": 3
+                }
+            ]
+        },
+        "sgp-core-1": {
+            "fra-core-2": [
+                {
+                    "our_interface": "GigabitEthernet0/0/0/0",
+                    "our_numeric": 1,
+                    "their_interface": "ge-0/0/0",
+                    "their_numeric": 1
+                }
+            ],
+            "kul-core-1": [
+                {
+                    "our_interface": "GigabitEthernet0/0/0/3",
+                    "our_numeric": 4,
+                    "their_interface": "GigabitEthernet0/0/0/3",
+                    "their_numeric": 4
+                }
+            ],
+            "par-core-1": [
+                {
+                    "our_interface": "GigabitEthernet0/0/0/1",
+                    "our_numeric": 2,
+                    "their_interface": "1/1/1",
+                    "their_numeric": 1
+                }
+            ],
+            "png-edge-1": [
+                {
+                    "our_interface": "GigabitEthernet0/0/0/2",
+                    "our_numeric": 3,
+                    "their_interface": "GigabitEthernet0/0/0/0",
+                    "their_numeric": 1
+                }
+            ]
+        }
+    },
+    "routers": {
+        "ams-core-1": {
+            "id": 1,
+            "interfaces": {
+                "1": "GigabitEthernet0/0/0/0",
+                "2": "GigabitEthernet0/0/0/1",
+                "3": "GigabitEthernet0/0/0/2",
+                "4": "GigabitEthernet0/0/0/3",
+                "5": "GigabitEthernet0/0/0/4",
+                "6": "GigabitEthernet0/0/0/5",
+                "7": "GigabitEthernet0/0/0/6"
+            },
+            "run_args": "--foo bar 1",
+            "type": "xrv",
+            "version": "5.1.1.54U"
+        },
+        "ams-core-2": {
+            "id": 2,
+            "interfaces": {
+                "1": "GigabitEthernet0/0/0/0",
+                "2": "GigabitEthernet0/0/0/1",
+                "3": "GigabitEthernet0/0/0/2",
+                "4": "GigabitEthernet0/0/0/3",
+                "5": "GigabitEthernet0/0/0/4",
+                "6": "GigabitEthernet0/0/0/5",
+                "7": "GigabitEthernet0/0/0/6"
+            },
+            "run_args": [
+                "--foo",
+                "bar",
+                1
+            ],
+            "type": "xrv",
+            "version": "5.1.1.54U"
+        },
+        "ams-edge-1": {
+            "id": 100,
+            "interfaces": {
+                "1": "GigabitEthernet0/0/0/0",
+                "2": "GigabitEthernet0/0/0/1",
+                "3": "GigabitEthernet0/0/0/2"
+            },
+            "type": "xrv",
+            "version": "5.1.1.54U"
+        },
+        "fra-core-1": {
+            "id": 3,
+            "interfaces": {
+                "1": "ge-0/0/0",
+                "2": "ge-0/0/1",
+                "3": "ge-0/0/2",
+                "4": "ge-0/0/3",
+                "5": "ge-0/0/4",
+                "6": "ge-0/0/5"
+            },
+            "run_args": {
+                "--foo": [
+                    "bar",
+                    1
+                ]
+            },
+            "type": "vmx",
+            "version": "16.1R1.7"
+        },
+        "fra-core-2": {
+            "id": 4,
+            "interfaces": {
+                "1": "ge-0/0/0",
+                "2": "ge-0/0/1",
+                "3": "ge-0/0/2",
+                "4": "ge-0/0/3",
+                "5": "ge-0/0/4",
+                "6": "ge-0/0/5",
+                "7": "ge-0/0/6",
+                "8": "ge-0/0/7"
+            },
+            "type": "vmx",
+            "version": "16.1R1.7"
+        },
+        "fra-edge-1": {
+            "id": 101,
+            "interfaces": {
+                "1": "ge-0/0/0",
+                "2": "ge-0/0/1"
+            },
+            "type": "vmx",
+            "version": "16.1R1.7"
+        },
+        "kul-core-1": {
+            "id": 8,
+            "interfaces": {
+                "1": "GigabitEthernet0/0/0/0",
+                "2": "GigabitEthernet0/0/0/1",
+                "3": "GigabitEthernet0/0/0/2",
+                "4": "GigabitEthernet0/0/0/3"
+            },
+            "type": "xrv",
+            "version": "5.1.1.54U"
+        },
+        "par-core-1": {
+            "id": 5,
+            "interfaces": {
+                "1": "1/1/1",
+                "2": "1/1/2",
+                "3": "1/1/3",
+                "4": "1/1/4",
+                "5": "1/1/5",
+                "6": "1/1/6",
+                "7": "2/1/1",
+                "8": "2/1/2"
+            },
+            "type": "sros",
+            "version": "13.0.B1-4281"
+        },
+        "par-core-2": {
+            "id": 6,
+            "interfaces": {
+                "1": "1/1/1",
+                "2": "1/1/2",
+                "3": "1/1/3",
+                "4": "1/1/4",
+                "5": "1/1/5",
+                "6": "1/1/6"
+            },
+            "type": "sros",
+            "version": "13.0.B1-4281"
+        },
+        "par-edge-1": {
+            "id": 102,
+            "interfaces": {
+                "1": "1/1/1",
+                "2": "1/1/2"
+            },
+            "type": "sros",
+            "version": "13.0.B1-4281"
+        },
+        "png-edge-1": {
+            "id": 103,
+            "interfaces": {
+                "1": "GigabitEthernet0/0/0/0",
+                "2": "GigabitEthernet0/0/0/1"
+            },
+            "type": "xrv",
+            "version": "5.1.1.54U"
+        },
+        "sgp-core-1": {
+            "id": 7,
+            "interfaces": {
+                "1": "GigabitEthernet0/0/0/0",
+                "2": "GigabitEthernet0/0/0/1",
+                "3": "GigabitEthernet0/0/0/2",
+                "4": "GigabitEthernet0/0/0/3"
+            },
+            "type": "xrv",
+            "version": "5.1.1.54U"
+        }
+    }
+}


### PR DESCRIPTION
- Add CI test for the topomachine container
- Install extra tools (git, make) that make it possible to use the topomachine image directly in CI for keeping generated outputs (lltopo, scripts) up to date