### PR TITLE
Teach topomachine to use static interface assignment

### DIFF
--- a/topology-machine/README.md
+++ b/topology-machine/README.md
@@ -41,7 +41,9 @@ and routers in *fullmeshes* are defined in the configuration file. This makes
 the interface assignment more stable when changing the topology. It also makes
 the assignment more natural, as we tend to list the important routers (like PE
 routers) in the topology first, followed by CPEs and the like. The interfaces on
-the devices listed first will be assigned lower numbers.
+the devices listed first will be assigned lower numbers. As a last resort when
+you really really need to use a specific interface for a link, you can assign a
+static numeric interface ID in the *p2p* section of the topology file.
 
 topology machine is able to run the machines for you, i.e. execute docker run
 for the routers defined in the configuration file and start vr-xcon with the
@@ -145,6 +147,19 @@ router twice:
 
  * foo <-> a
  * foo <-> a
+
+The array of routers on the right side may also include static interface assignment. Use the format `router:interface` to assign a specific interface to a link. For example:
+
+```
+{
+    "p2p": {
+        "foo": [ "a", "b:2" ]
+    }
+}
+```
+
+ * foo <-> a/1
+ * foo <-> b/2
 
 Configuration section "fullmeshes"
 ----------------------------------

--- a/topology-machine/example-hltopo.json
+++ b/topology-machine/example-hltopo.json
@@ -19,7 +19,7 @@
 		"ams-edge-1": [ "ams-core-1", "ams-core-2" ],
 		"fra-edge-1": [ "fra-core-1", "fra-core-2" ],
 		"par-edge-1": [ "par-core-1", "par-core-2" ],
-		"png-edge-1": [ "sgp-core-1", "kul-core-1" ]
+		"png-edge-1": [ "sgp-core-1", "kul-core-1:42" ]
 	},
 	"fullmeshes": {
 		"europe": [ "ams-core-1", "ams-core-2", "fra-core-1", "fra-core-2", "par-core-1", "par-core-2" ],

--- a/topology-machine/example-lltopo.json
+++ b/topology-machine/example-lltopo.json
@@ -158,15 +158,15 @@
                 "router": "png-edge-1"
             },
             "right": {
-                "interface": "GigabitEthernet0/0/0/2",
-                "numeric": 3,
+                "interface": "GigabitEthernet0/0/0/41",
+                "numeric": 42,
                 "router": "kul-core-1"
             }
         },
         {
             "left": {
-                "interface": "GigabitEthernet0/0/0/3",
-                "numeric": 4,
+                "interface": "GigabitEthernet0/0/0/2",
+                "numeric": 3,
                 "router": "kul-core-1"
             },
             "right": {
@@ -628,16 +628,16 @@
             ],
             "png-edge-1": [
                 {
-                    "our_interface": "GigabitEthernet0/0/0/2",
-                    "our_numeric": 3,
+                    "our_interface": "GigabitEthernet0/0/0/41",
+                    "our_numeric": 42,
                     "their_interface": "GigabitEthernet0/0/0/1",
                     "their_numeric": 2
                 }
             ],
             "sgp-core-1": [
                 {
-                    "our_interface": "GigabitEthernet0/0/0/3",
-                    "our_numeric": 4,
+                    "our_interface": "GigabitEthernet0/0/0/2",
+                    "our_numeric": 3,
                     "their_interface": "GigabitEthernet0/0/0/3",
                     "their_numeric": 4
                 }
@@ -782,8 +782,8 @@
                 {
                     "our_interface": "GigabitEthernet0/0/0/1",
                     "our_numeric": 2,
-                    "their_interface": "GigabitEthernet0/0/0/2",
-                    "their_numeric": 3
+                    "their_interface": "GigabitEthernet0/0/0/41",
+                    "their_numeric": 42
                 }
             ],
             "sgp-core-1": [
@@ -808,8 +808,8 @@
                 {
                     "our_interface": "GigabitEthernet0/0/0/3",
                     "our_numeric": 4,
-                    "their_interface": "GigabitEthernet0/0/0/3",
-                    "their_numeric": 4
+                    "their_interface": "GigabitEthernet0/0/0/2",
+                    "their_numeric": 3
                 }
             ],
             "par-core-1": [
@@ -924,7 +924,7 @@
                 "1": "GigabitEthernet0/0/0/0",
                 "2": "GigabitEthernet0/0/0/1",
                 "3": "GigabitEthernet0/0/0/2",
-                "4": "GigabitEthernet0/0/0/3"
+                "42": "GigabitEthernet0/0/0/41"
             },
             "type": "xrv",
             "version": "5.1.1.54U"

--- a/topology-machine/topomachine
+++ b/topology-machine/topomachine
@@ -4,6 +4,7 @@ import json
 import os
 import sys
 from collections import OrderedDict
+from typing import Optional, Tuple
 
 import jinja2
 
@@ -37,14 +38,15 @@ class VrTopo:
         links = []
 
         # expand p2p links
-        def p2p():
+        def p2p(instance):
             nonlocal links
             if 'p2p' in config:
                 for router in maybe_sorted(config['p2p']):
                     neighbors = config['p2p'][router]
                     for neighbor in neighbors:
+                        name, numeric = instance.router_name_interface(neighbor)
                         links.append({ 'left': { 'router': router }, 'right': {
-                            'router': neighbor }})
+                            'router': name, 'numeric': numeric }})
 
         # expand fullmesh into links
         def fullmesh():
@@ -58,9 +60,9 @@ class VrTopo:
         # expand fullmeshes before p2p if keep_order is set and fullmeshes is defined before p2p
         if keep_order and 'fullmeshes' in config and 'p2p' in config and tuple(config).index('fullmeshes') < tuple(config).index('p2p'):
             fullmesh()
-            p2p()
+            p2p(self)
         else:
-            p2p()
+            p2p(self)
             fullmesh()
 
         self.links = self.assign_interfaces(links)
@@ -82,9 +84,10 @@ class VrTopo:
             for hub in sorted(config['hubs']):
                 self.hubs[hub] = []
                 for router in config['hubs'][hub]:
+                    name, interface = self.router_name_interface(router)
                     ep = {
-                        'router': router,
-                        'numeric': self.get_interface(router)
+                        'router': name,
+                        'numeric': self.get_interface(name, interface)
                     }
                     ep['interface'] = self.intf_num_to_name(router, ep['numeric'])
                     self.hubs[hub].append(ep)
@@ -94,6 +97,14 @@ class VrTopo:
             if 'interfaces' in val:
                 for num_id in val['interfaces']:
                     val['interfaces'][num_id] = self.intf_num_to_name(router, num_id)
+
+    @staticmethod
+    def router_name_interface(router: str) -> Tuple[str, Optional[int]]:
+        if ':' in router:
+            s = router.split(':')
+            return s[0], int(s[1])
+        else:
+            return router, None
 
     @staticmethod
     def expand_fullmesh(routers):
@@ -126,14 +137,20 @@ class VrTopo:
     def assign_interfaces(self, links):
         """ Assign numeric interfaces to links
         """
+        # first pass - reserve and validate static interface assignments
+        for link in links:
+            right = link['right']
+            if right_numeric := right.get('numeric', None):
+                self.get_interface(right['router'], right_numeric)
+
         # assign interfaces to links
         for link in links:
             left = link['left']
-            left['numeric'] = self.get_interface(left['router'])
+            left['numeric'] = self.get_interface(left['router'], left.get('numeric', None))
             left['interface'] = self.intf_num_to_name(left['router'], left['numeric'])
 
             right = link['right']
-            right['numeric'] = self.get_interface(right['router'])
+            right['numeric'] = self.get_interface(right['router'], right.get('numeric', None))
             right['interface'] = self.intf_num_to_name(right['router'], right['numeric'])
 
         return links
@@ -169,14 +186,19 @@ class VrTopo:
         return None
 
 
-    def get_interface(self, router):
-        """ Return next available interface
+    def get_interface(self, router, interface=None):
+        """ Return next available interface, or allocate desired numeric interface
         """
         if router not in self.routers:
             raise ValueError("Router %s is not defined in config" % router)
         if 'interfaces' not in self.routers[router]:
             self.routers[router]['interfaces'] = {}
         intfs = self.routers[router]['interfaces']
+        if interface:
+            if interface in intfs and intfs[interface] != interface:
+                raise ValueError(f"Interface {interface} already assigned for {router}")
+            intfs[interface] = interface
+            return interface
 
         i = 1
         for intf in range(len(intfs)):


### PR DESCRIPTION
In some rare cases we want the link between devices to be created on a specific (static) interface. It is now possible to specify the desired numeric interface ID in the p2p or hub link specifications:

{"p2p": {"pe": ["cpe:3"] }}

Under normal circumstances the "pe" and "cpe" devices would be connected on the first available interface - 1. We can override "cpe" interface assignment by providing the value after the name.