### PR TITLE
Topomachine + xcon access switch emulation

### DIFF
--- a/topology-machine/README.md
+++ b/topology-machine/README.md
@@ -148,12 +148,14 @@ router twice:
  * foo <-> a
  * foo <-> a
 
-The array of routers on the right side may also include static interface assignment. Use the format `router:interface` to assign a specific interface to a link. For example:
+The array of routers on the right side may also include static interface
+assignment. Use the a dict to assign a specific interface to a link. For
+example:
 
 ```
 {
     "p2p": {
-        "foo": [ "a", "b:2" ]
+        "foo": [ "a", {"router": b, "numeric": 42} ]
     }
 }
 ```
@@ -161,6 +163,24 @@ The array of routers on the right side may also include static interface assignm
  * foo <-> a/1
  * foo <-> b/2
 
+ Another option is to have links where you want to emulate an access switch
+ between the two endpoints. 802.1q VLAN tags will be automatically stripped from
+ the frames sent from the left side to the right side. And conversely, the right
+ side is expected to send untagged frames which are then tagged before being
+ sent to the left side. For example:
+
+ ```
+ "p2p": {
+        "foo": [ "b", {"router": "b", "vlan": 123}, {"router": "b", "vlan": 456}]
+    }
+ ```
+
+ Generated links:
+
+ * foo <-> b with untagged traffic
+ * foo <-> b:123 where foo is sending tagged traffic with vlan 123 and b receives untagged traffic.
+ * foo <-> b:456 where foo is sending tagged traffic with vlan 456 and b receives untagged traffic.
+ 
 Configuration section "fullmeshes"
 ----------------------------------
 Last but not least we have the fullmeshes section which helps you build one or

--- a/topology-machine/example-hltopo.json
+++ b/topology-machine/example-hltopo.json
@@ -19,7 +19,7 @@
 		"ams-edge-1": [ "ams-core-1", "ams-core-2" ],
 		"fra-edge-1": [ "fra-core-1", "fra-core-2" ],
 		"par-edge-1": [ "par-core-1", "par-core-2" ],
-		"png-edge-1": [ "sgp-core-1", "kul-core-1:42" ]
+		"png-edge-1": [ "sgp-core-1", {"router": "kul-core-1", "numeric": 42, "vlan": 1337} ]
 	},
 	"fullmeshes": {
 		"europe": [ "ams-core-1", "ams-core-2", "fra-core-1", "fra-core-2", "par-core-1", "par-core-2" ],

--- a/topology-machine/example-lltopo.json
+++ b/topology-machine/example-lltopo.json
@@ -160,7 +160,8 @@
             "right": {
                 "interface": "GigabitEthernet0/0/0/41",
                 "numeric": 42,
-                "router": "kul-core-1"
+                "router": "kul-core-1",
+                "vlan": 1337
             }
         },
         {
@@ -783,7 +784,8 @@
                     "our_interface": "GigabitEthernet0/0/0/1",
                     "our_numeric": 2,
                     "their_interface": "GigabitEthernet0/0/0/41",
-                    "their_numeric": 42
+                    "their_numeric": 42,
+                    "vlan": 1337
                 }
             ],
             "sgp-core-1": [

--- a/topology-machine/topomachine
+++ b/topology-machine/topomachine
@@ -44,9 +44,12 @@ class VrTopo:
                 for router in maybe_sorted(config['p2p']):
                     neighbors = config['p2p'][router]
                     for neighbor in neighbors:
-                        name, numeric = instance.router_name_interface(neighbor)
-                        links.append({ 'left': { 'router': router }, 'right': {
-                            'router': name, 'numeric': numeric }})
+                        name, numeric, vlan = instance.router_link(neighbor)
+                        link = { 'left': { 'router': router }, 'right': {
+                            'router': name, 'numeric': numeric }}
+                        if vlan:
+                            link['right']['vlan'] = vlan
+                        links.append(link)
 
         # expand fullmesh into links
         def fullmesh():
@@ -76,6 +79,8 @@ class VrTopo:
                         'their_interface': link[b]['interface'],
                         'our_numeric': link[a]['numeric'],
                         'their_numeric': link[b]['numeric']}
+                if 'vlan' in link[b]:
+                    spec['vlan'] = link[b]['vlan']
                 if link[b]['router'] not in self.links_by_nodes[link[a]['router']]:
                     self.links_by_nodes[link[a]['router']][link[b]['router']] = []
                 self.links_by_nodes[link[a]['router']][link[b]['router']].append(spec)
@@ -84,12 +89,14 @@ class VrTopo:
             for hub in sorted(config['hubs']):
                 self.hubs[hub] = []
                 for router in config['hubs'][hub]:
-                    name, interface = self.router_name_interface(router)
+                    name, interface, vlan = self.router_link(router)
                     ep = {
                         'router': name,
                         'numeric': self.get_interface(name, interface)
                     }
                     ep['interface'] = self.intf_num_to_name(router, ep['numeric'])
+                    if vlan:
+                        ep['vlan'] = vlan
                     self.hubs[hub].append(ep)
 
         for router in sorted(self.routers):
@@ -99,12 +106,11 @@ class VrTopo:
                     val['interfaces'][num_id] = self.intf_num_to_name(router, num_id)
 
     @staticmethod
-    def router_name_interface(router: str) -> Tuple[str, Optional[int]]:
-        if ':' in router:
-            s = router.split(':')
-            return s[0], int(s[1])
-        else:
-            return router, None
+    def router_link(router: str|dict) -> Tuple[str, Optional[int], Optional[int]]:
+        if isinstance(router, str):
+            return router, None, None
+
+        return router['router'], router.get('numeric', None), router.get('vlan', None)
 
     @staticmethod
     def expand_fullmesh(routers):
@@ -243,7 +249,6 @@ def run_topology(config, dry_run, with_trace=False, xcon_ng=False):
     if 'routers' not in config:
         print("No routers in config")
         sys.exit(1)
-
     trace = ''
     if with_trace:
         trace = '--trace'
@@ -312,11 +317,15 @@ def run_topology(config, dry_run, with_trace=False, xcon_ng=False):
                 cmd.extend(["--link", "%s%s:%s%s" % (args.prefix, vr, args.prefix, vr)])
         cmd.append(docker_registry + "vr-xcon")
         cmd.append("--p2p")
-        cmd.extend(["%s%s/%s--%s%s/%s" % (args.prefix, link["left"]["router"],
-                                           link["left"]["numeric"],
-                                           args.prefix,
-                                           link["right"]["router"],
-                                           link["right"]["numeric"]) for link in config['links']])
+        for link in config["links"]:
+            vlan = ""
+            if "vlan" in link["right"]:
+                vlan = ":%s" % link["right"]["vlan"]
+            cmd.extend(["%s%s/%s--%s%s/%s%s" % (args.prefix, link["left"]["router"],
+                                                           link["left"]["numeric"],
+                                                           args.prefix,
+                                                           link["right"]["router"],
+                                                           link["right"]["numeric"], vlan)])
         output,_ = run_command(["docker", "inspect", "--format", "{{.State.Running}}", name])
         if not dry_run and output.strip() == "true":
             output,_ = run_command(["docker", "inspect", "--format", "{{.State.Health.Status}}", name])

--- a/vr-xcon/Dockerfile
+++ b/vr-xcon/Dockerfile
@@ -30,6 +30,8 @@ RUN apt-get update -qy \
     python3-ipy \
     tcpdump \
     telnet \
+    python3-pip \
+ && pip3 install scapy \
  && rm -rf /var/lib/apt/lists/*
 
 ADD xcon.py /

--- a/vr-xcon/README.md
+++ b/vr-xcon/README.md
@@ -56,7 +56,7 @@ sends packets tagged with vlan-id 123, but you would like to forward them to vr2
 untagged (to simplify test environment for example) you can do this with:
 
 ```
-docker run -d --privileged --name vr-xcon --link vr1 --link vr2 --p2p vr1/1:123--vr2/1
+docker run -d --privileged --name vr-xcon --link vr1 --link vr2 --p2p vr1/1--vr2/1:123
 ```
 
 Packets from vr1  to vr2 without vlan-id 123 will be discarded, while traffic going from vr2
@@ -64,7 +64,7 @@ towards vr1 will be tagged with vlan-id 123. It is possible to specify vlan-id a
 the other side of the link:
 
 ```
-docker run -d --privileged --name vr-xcon --link vr1 --link vr2 --p2p vr1/1--vr2/1:123
+docker run -d --privileged --name vr-xcon --link vr1 --link vr2 --p2p vr1/1:123--vr2/1
 ```
 
 Note that having vlan tag on both sides (changing vlan-id) is not supported. 

--- a/vr-xcon/README.md
+++ b/vr-xcon/README.md
@@ -51,6 +51,24 @@ docker run -d --privileged --name vr-xcon --link vr1 --link vr2 --link vr3 vr-xc
 ```
 Note how --p2p is not repeated and the arguments to it are simply appended.
 
+Tcp2Bridge mode also supports tagging/stripping VLANs from packets. Lets say vr1 
+sends packets tagged with vlan-id 123, but you would like to forward them to vr2
+untagged (to simplify test environment for example) you can do this with:
+
+```
+docker run -d --privileged --name vr-xcon --link vr1 --link vr2 --p2p vr1/1:123--vr2/1
+```
+
+Packets from vr1  to vr2 without vlan-id 123 will be discarded, while traffic going from vr2
+towards vr1 will be tagged with vlan-id 123. It is possible to specify vlan-id also on 
+the other side of the link:
+
+```
+docker run -d --privileged --name vr-xcon --link vr1 --link vr2 --p2p vr1/1--vr2/1:123
+```
+
+Note that having vlan tag on both sides (changing vlan-id) is not supported. 
+
 It's possible to use the `--debug` option to have a debug written out for every
 packet.
 

--- a/vr-xcon/xcon.py
+++ b/vr-xcon/xcon.py
@@ -11,6 +11,7 @@ import struct
 import subprocess
 import sys
 import time
+from scapy.all import Ether, Dot1Q
 
 
 def handle_SIGCHLD(signal, frame):
@@ -220,9 +221,14 @@ class TcpBridge:
     def __init__(self):
         self.logger = logging.getLogger()
         self.sockets = []
+        self.buffers = {}
         self.socket2remote = {}
         self.socket2hostintf = {}
 
+        self.tcp_states = {}
+        self.tcp_remainings = {}
+
+        self.vlans = {}
 
     def hostintf2addr(self, hostintf):
         hostname, interface = hostintf.split("/")
@@ -237,9 +243,20 @@ class TcpBridge:
 
     def add_p2p(self, p2p):
         source, destination = p2p.split("--")
+        # --p2p A/1--B/1:123 means that for packets going 
+        # A->B: discard packets without vlan 123, remove tag 123 and forward the rest
+        # B->A: add vlan tag 123
+        if ':' in source and ':' in destination:
+            self.logger.error("Vlan tagging/stripping supported for single vlan only, stopping...")
+            sys.exit(1)
+        elif ':' in source:
+            source, vlan = source.split(':')
+            self.vlans[source] = vlan
+        elif ':' in destination:
+            destination, vlan = destination.split(':')
+            self.vlans[destination] = vlan
         src_router, src_interface = source.split("/")
         dst_router, dst_interface = destination.split("/")
-
         src = self.hostintf2addr(source)
         dst = self.hostintf2addr(destination)
 
@@ -249,6 +266,14 @@ class TcpBridge:
         # dict to map back to hostname & interface
         self.socket2hostintf[left] = "%s/%s" % (src_router, src_interface)
         self.socket2hostintf[right] = "%s/%s" % (dst_router, dst_interface)
+
+        # each socket needs  separate buffer and tcp vars
+        self.buffers[left] = b''
+        self.buffers[right] = b''
+        self.tcp_states[left] = 0
+        self.tcp_states[right] = 0
+        self.tcp_remainings[left] = 0
+        self.tcp_remainings[right] = 0
 
         try:
             left.connect(src)
@@ -267,7 +292,24 @@ class TcpBridge:
         self.socket2remote[left] = right
         self.socket2remote[right] = left
 
+    def tag_packet(self, packet, vlan_id):
+        layer = packet.getlayer(Ether)
+        # adjust ether type
+        layer.type = 0x8100
+        # add 802.1q layer between Ether and IP
+        dot1q = Dot1Q(vlan=int(vlan_id))
+        dot1q.add_payload(layer.payload)
+        layer.remove_payload()
+        layer.add_payload(dot1q)
+        return packet
 
+    def untag_packet(self, packet):
+        dot1q_payload = packet[Dot1Q].payload
+        packet[Ether].remove_payload()
+        packet[Ether].add_payload(dot1q_payload)
+        # delete type so it is regenerated scapy
+        del packet[Ether].type
+        return packet
 
     def work(self):
         while True:
@@ -298,18 +340,77 @@ class TcpBridge:
                     continue
 
                 if len(buf) == 0:
+                    # track current state of TCP side tunnel. 0 = reading size, 1 = reading packet
+                    self.tcp_states[i] = 0
+                    self.buffers[i] = b''
+                    self.tcp_remainings[i] = 0
                     return
-                self.logger.debug("%05d bytes %s -> %s " % (len(buf), self.socket2hostintf[i], self.socket2hostintf[remote]))
-                try:
-                    remote.send(buf)
-                except BrokenPipeError:
-                    self.logger.warning("unable to send packet %05d bytes %s -> %s due to remote being down, trying reconnect" % (len(buf), self.socket2hostintf[i], self.socket2hostintf[remote]))
-                    try:
-                        remote.connect(self.hostintf2addr(self.socket2hostintf[remote]))
-                        self.logger.debug("connect to %s successful" % self.socket2hostintf[remote])
-                    except Exception as exc:
-                        self.logger.warning("connect failed %s" % str(exc))
-                    continue
+                self.buffers[i] += buf
+                self.logger.debug("%s: read %d bytes from tcp, buffer length %d" % (self.socket2hostintf[i], len(buf), len(self.buffers[i])))
+                while True:
+                    if self.tcp_states[i] == 0:
+                        # we want to read the size, which is 4 bytes, if we
+                        # don't have enough bytes wait for the next spin
+                        if not len(self.buffers[i]) > 4:
+                            self.logger.debug("%s: reading size - less than 4 bytes available in buf; waiting for next spin" % self.socket2hostintf[i])
+                            break
+                        size = socket.ntohl(struct.unpack("I", self.buffers[i][:4])[0]) # first 4 bytes is size of packet
+                        self.buffers[i] = self.buffers[i][4:] # remove first 4 bytes of buf
+                        self.tcp_remainings[i] = size
+                        self.tcp_states[i] = 1
+                        self.logger.debug("%s: reading size - pkt size: %d" % (self.socket2hostintf[i], self.tcp_remainings[i]))
+
+                    if self.tcp_states[i] == 1: # read packet data
+                        # we want to read the whole packet, which is specified
+                        # by tcp_remainings[i], if we don't have enough bytes we
+                        # wait for the next spin
+                        if len(self.buffers[i]) < self.tcp_remainings[i]:
+                            self.logger.debug("%s: reading packet - less than remaining bytes; waiting for next spin" % self.socket2hostintf[i])
+                            break
+                        self.logger.debug("%s: reading packet - reading %d bytes" % (self.socket2hostintf[i], self.tcp_remainings[i]))
+                        payload = self.buffers[i][:self.tcp_remainings[i]]
+                        self.buffers[i] = self.buffers[i][self.tcp_remainings[i]:]
+                        self.tcp_remainings[i] = 0
+                        self.tcp_states[i] = 0
+
+                        # if vlan exists for remote we need to look into the packet if vlan tag exists
+                        # if yes we need to strip tag before sending it to remote
+                        # if no then we need to discard this packet
+                        if self.socket2hostintf[remote] in self.vlans:
+                            s_packet = Ether(payload)
+                            if s_packet.haslayer(Dot1Q):
+                                self.logger.debug('%s: VlanID %s' %  (self.socket2hostintf[i], str(s_packet[Dot1Q].vlan)))
+                                if int(s_packet[Dot1Q].vlan) != int(self.vlans[self.socket2hostintf[remote]]):
+                                    self.logger.debug("%s: discarding packet with different vlan %s" % (self.socket2hostintf[i], s_packet.summary()))
+                                    continue
+                                s_packet = self.untag_packet(s_packet)
+                                # regenerate packet so fields are recomputed
+                                s_packet = Ether(bytes(s_packet))
+                                payload = bytes(s_packet)
+                            else:
+                                self.logger.debug("%s: discarding untagged packet %s" % (self.socket2hostintf[i], s_packet.summary()))
+                                continue
+                        # if vlan exists for source we need to tag traffic with corresponding vlan id before sending
+                        elif self.socket2hostintf[i] in self.vlans:
+                            vlan_id = self.vlans[self.socket2hostintf[i]]
+                            s_packet = Ether(payload)
+                            self.logger.debug('%s Tagging packet with VlanID %s' % (self.socket2hostintf[i], vlan_id))
+                            s_packet = self.tag_packet(s_packet, vlan_id)
+                            # regenerate packet so fields are recomputed
+                            s_packet = Ether(bytes(s_packet))
+                            payload = bytes(s_packet)
+                        self.logger.debug("%05d bytes %s -> %s " % (len(payload), self.socket2hostintf[i], self.socket2hostintf[remote]))
+                        try:
+                            buf = struct.pack("I", socket.htonl(len(payload))) + payload
+                            remote.send(buf)
+                        except BrokenPipeError:
+                            self.logger.warning("unable to send packet %05d bytes %s -> %s due to remote being down, trying reconnect" % (len(buf), self.socket2hostintf[i], self.socket2hostintf[remote]))
+                            try:
+                                remote.connect(self.hostintf2addr(self.socket2hostintf[remote]))
+                                self.logger.debug("connect to %s successful" % self.socket2hostintf[remote])
+                            except Exception as exc:
+                                self.logger.warning("connect failed %s" % str(exc))
+                            continue
 
 
 class TcpHub:

--- a/vr-xcon/xcon.py
+++ b/vr-xcon/xcon.py
@@ -251,10 +251,10 @@ class TcpBridge:
             sys.exit(1)
         elif ':' in source:
             source, vlan = source.split(':')
-            self.vlans[source] = vlan
+            self.vlans[destination] = vlan
         elif ':' in destination:
             destination, vlan = destination.split(':')
-            self.vlans[destination] = vlan
+            self.vlans[source] = vlan
         src_router, src_interface = source.split("/")
         dst_router, dst_interface = destination.split("/")
         src = self.hostintf2addr(source)


### PR DESCRIPTION
A p2p link in hltopo.json between two endpoints can be additionally
configured for VLAN tagging/untagging, if the link specification
contains the "vlan" field:

  {
    "p2p": {
      "276-R1-1": [ "cust1", "ncs", {"router": "hgw-1", vlan: 2001} ]
    }
  }

In the example, the p2p link between 276-R1-1 and hgw-1 will be
configured to tag/untag traffic with VLAN 2001:
- 276-R1-1 -> hgw-1: VLAN tag 2001 will be stripped (frames tagged
otherwise will be dropped)
- hgw-1 -> 276-R1-1: VLAN tag 2001 will be added

This is achieved by passing the configuration to vr-xcon: '--p2p
276-R1-1--hgw-1:2001'.