### PR TITLE
Pull default launch.py args from env vars

### DIFF
--- a/c8000v/docker/launch.py
+++ b/c8000v/docker/launch.py
@@ -200,10 +200,10 @@ class C8000v_installer(C8000v):
 if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser(description='')
-    parser.add_argument('--trace', action='store_true', help='enable trace level logging')
-    parser.add_argument('--username', default='vrnetlab', help='Username')
-    parser.add_argument('--password', default='VR-netlab9', help='Password')
-    parser.add_argument('--install', action='store_true', help='Install C8000v')
+    parser.add_argument('--trace', default=vrnetlab.bool_from_env('TRACE'), action='store_true', help='enable trace level logging')
+    parser.add_argument('--username', default=os.getenv('USERNAME', 'vrnetlab'), help='Username')
+    parser.add_argument('--password', default=os.getenv('PASSWORD', 'VR-netlab9'), help='Password')
+    parser.add_argument('--install', default=vrnetlab.bool_from_env('INSTALL'), action='store_true', help='Install C8000v')
     args = parser.parse_args()
 
     LOG_FORMAT = "%(asctime)s: %(module)-10s %(levelname)-8s %(message)s"

--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -50,6 +50,21 @@ def run_command(cmd, cwd=None, background=False):
     return res
 
 
+def bool_from_env(env_var: str, default: bool=False):
+    """Convert environment variable to boolean
+
+    For example, 'True', 'true', '1' and 'yes' are all considered True.
+    """
+    return os.getenv(env_var, str(default)).lower() in ['true', '1', 'yes']
+
+
+def list_from_env(env_var: str, default: list=[]):
+    """Convert environment variable to list
+
+    The environment variable should be a space separate list of values.
+    """
+    return os.getenv(env_var, ' '.join(default)).split()
+
 
 class VM:
     def __str__(self):

--- a/csr/docker/launch.py
+++ b/csr/docker/launch.py
@@ -193,10 +193,10 @@ class CSR_installer(CSR):
 if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser(description='')
-    parser.add_argument('--trace', action='store_true', help='enable trace level logging')
-    parser.add_argument('--username', default='vrnetlab', help='Username')
-    parser.add_argument('--password', default='VR-netlab9', help='Password')
-    parser.add_argument('--install', action='store_true', help='Install CSR')
+    parser.add_argument('--trace', default=vrnetlab.bool_from_env('TRACE'), action='store_true', help='enable trace level logging')
+    parser.add_argument('--username', default=os.getenv('USERNAME', 'vrnetlab'), help='Username')
+    parser.add_argument('--password', default=os.getenv('PASSWORD', 'VR-netlab9'), help='Password')
+    parser.add_argument('--install', default=vrnetlab.bool_from_env('INSTALL'), action='store_true', help='Install CSR')
     args = parser.parse_args()
 
     LOG_FORMAT = "%(asctime)s: %(module)-10s %(levelname)-8s %(message)s"

--- a/nxos/docker/launch.py
+++ b/nxos/docker/launch.py
@@ -115,9 +115,9 @@ class NXOS(vrnetlab.VR):
 if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser(description='')
-    parser.add_argument('--trace', action='store_true', help='enable trace level logging')
-    parser.add_argument('--username', default='vrnetlab', help='Username')
-    parser.add_argument('--password', default='VR-netlab9', help='Password')
+    parser.add_argument('--trace', default=vrnetlab.bool_from_env('TRACE'), action='store_true', help='enable trace level logging')
+    parser.add_argument('--username', default=os.getenv('USERNAME', 'vrnetlab'), help='Username')
+    parser.add_argument('--password', default=os.getenv('PASSWORD', 'VR-netlab9'), help='Password')
     args = parser.parse_args()
 
     LOG_FORMAT = "%(asctime)s: %(module)-10s %(levelname)-8s %(message)s"

--- a/nxos9kv/docker/launch.py
+++ b/nxos9kv/docker/launch.py
@@ -141,11 +141,11 @@ class NXOS9K(vrnetlab.VR):
 def main():
     """Main method"""
     parser = argparse.ArgumentParser()
-    parser.add_argument('--trace', action='store_true', help='enable trace level logging')
-    parser.add_argument('--username', default='vrnetlab', help='Username')
-    parser.add_argument('--password', default='VR-netlab9', help='Password')
-    parser.add_argument('--bios', default='OVMF-pure-efi.fd', help='EFI bios image')
-    parser.add_argument('--num-nics', type=int, default=24, help='Number of NICs')
+    parser.add_argument('--trace', default=vrnetlab.bool_from_env('TRACE'), action='store_true', help='enable trace level logging')
+    parser.add_argument('--username', default=os.getenv('USERNAME', 'vrnetlab'), help='Username')
+    parser.add_argument('--password', default=os.getenv('PASSWORD', 'VR-netlab9'), help='Password')
+    parser.add_argument('--bios', default=os.getenv('BIOS', 'OVMF-pure-efi.fd'), help='EFI bios image')
+    parser.add_argument('--num-nics', type=int, default=int(os.getenv('NUM_NICS', 24)), help='Number of NICs')
     args = parser.parse_args()
 
     # check if the bios file exists

--- a/openwrt/docker/launch.py
+++ b/openwrt/docker/launch.py
@@ -107,9 +107,9 @@ class OpenWRT(vrnetlab.VR):
 if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser(description='')
-    parser.add_argument('--trace', action='store_true', help='enable trace level logging')
-    parser.add_argument('--username', default='vrnetlab', help='Username')
-    parser.add_argument('--password', default='VR-netlab9', help='Password')
+    parser.add_argument('--trace', default=vrnetlab.bool_from_env('TRACE'), action='store_true', help='enable trace level logging')
+    parser.add_argument('--username', default=os.getenv('USERNAME', 'vrnetlab'), help='Username')
+    parser.add_argument('--password', default=os.getenv('PASSWORD', 'VR-netlab9'), help='Password')
     args = parser.parse_args()
 
     LOG_FORMAT = "%(asctime)s: %(module)-10s %(levelname)-8s %(message)s"

--- a/routeros/docker/launch.py
+++ b/routeros/docker/launch.py
@@ -102,9 +102,9 @@ class ROS(vrnetlab.VR):
 if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser(description='')
-    parser.add_argument('--trace', action='store_true', help='enable trace level logging')
-    parser.add_argument('--username', default='vrnetlab', help='Username')
-    parser.add_argument('--password', default='VR-netlab9', help='Password')
+    parser.add_argument('--trace', default=vrnetlab.bool_from_env('TRACE'), action='store_true', help='enable trace level logging')
+    parser.add_argument('--username', default=os.getenv('USERNAME', 'vrnetlab'), help='Username')
+    parser.add_argument('--password', default=os.getenv('PASSWORD', 'VR-netlab9'), help='Password')
     args = parser.parse_args()
 
     LOG_FORMAT = "%(asctime)s: %(module)-10s %(levelname)-8s %(message)s"

--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -378,11 +378,11 @@ class SROS(vrnetlab.VR):
 if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser(description='')
-    parser.add_argument('--trace', action='store_true', help='enable trace level logging')
-    parser.add_argument('--username', default='vrnetlab', help='Username')
-    parser.add_argument('--password', default='VR-netlab9', help='Password')
-    parser.add_argument('--num-nics', default=5, help='Number of NICs')
-    parser.add_argument('--mode', choices=['cli', 'mixed', 'model-driven'], help='configuration mode of the system', default='cli')
+    parser.add_argument('--trace', default=vrnetlab.bool_from_env('TRACE'), action='store_true', help='enable trace level logging')
+    parser.add_argument('--username', default=os.getenv('USERNAME', 'vrnetlab'), help='Username')
+    parser.add_argument('--password', default=os.getenv('PASSWORD', 'VR-netlab9'), help='Password')
+    parser.add_argument('--num-nics', default=os.getenv('NUM_NICS', 5), help='Number of NICs')
+    parser.add_argument('--mode', default=os.getenv('MODE', 'cli'), choices=['cli', 'mixed', 'model-driven'], help='configuration mode of the system')
     args = parser.parse_args()
 
     LOG_FORMAT = "%(asctime)s: %(module)-10s %(levelname)-8s %(message)s"

--- a/ucpe-oneos/docker/launch.py
+++ b/ucpe-oneos/docker/launch.py
@@ -124,12 +124,12 @@ class UCPE(vrnetlab.VR):
 if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser(description='')
-    parser.add_argument('--trace', action='store_true', help='enable trace level logging')
-    parser.add_argument('--username', default='vrnetlab', help='Username')
-    parser.add_argument('--password', default='VR-netlab9', help='Password')
-    parser.add_argument('--uuid', help='Set UUID to a static value (for applying license)')
-    parser.add_argument('--license-key', nargs='*', help='One or more license keys to apply at bootstrap')
-    parser.add_argument('--license-activate', nargs='+', help='One or more licensed features to activate at bootstrap')
+    parser.add_argument('--trace', default=vrnetlab.bool_from_env('TRACE'), action='store_true', help='enable trace level logging')
+    parser.add_argument('--username', default=os.getenv('USERNAME', 'vrnetlab'), help='Username')
+    parser.add_argument('--password', default=os.getenv('PASSWORD', 'VR-netlab9'), help='Password')
+    parser.add_argument('--uuid', default=os.getenv('UUID'), help='Set UUID to a static value (for applying license)')
+    parser.add_argument('--license-key', nargs='*', default=vrnetlab.list_from_env('LICENSE_KEY'), help='One or more license keys to apply at bootstrap')
+    parser.add_argument('--license-activate', nargs='+', default=vrnetlab.list_from_env('LICENSE_ACTIVATE'), help='One or more licensed features to activate at bootstrap')
     args = parser.parse_args()
 
     if args.license_key and not args.license_activate:

--- a/veos/docker/launch.py
+++ b/veos/docker/launch.py
@@ -119,9 +119,9 @@ class VEOS(vrnetlab.VR):
 if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser(description='')
-    parser.add_argument('--trace', action='store_true', help='enable trace level logging')
-    parser.add_argument('--username', default='vrnetlab', help='Username')
-    parser.add_argument('--password', default='VR-netlab9', help='Password')
+    parser.add_argument('--trace', default=vrnetlab.bool_from_env('TRACE'), action='store_true', help='enable trace level logging')
+    parser.add_argument('--username', default=os.getenv('USERNAME', 'vrnetlab'), help='Username')
+    parser.add_argument('--password', default=os.getenv('PASSWORD', 'VR-netlab9'), help='Password')
     args = parser.parse_args()
 
     LOG_FORMAT = "%(asctime)s: %(module)-10s %(levelname)-8s %(message)s"

--- a/vmx/docker/launch.py
+++ b/vmx/docker/launch.py
@@ -375,13 +375,13 @@ class VMX_installer(VMX):
 if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser(description='')
-    parser.add_argument('--trace', action='store_true', help='enable trace level logging')
-    parser.add_argument('--username', default='vrnetlab', help='Username')
-    parser.add_argument('--password', default='VR-netlab9', help='Password')
-    parser.add_argument('--install', action='store_true', help='Install vMX')
-    parser.add_argument('--dual-re', action='store_true', help='Boot dual Routing Engines')
-    parser.add_argument('--num-nics', type=int, default=96, help='Number of NICs, this parameter is IGNORED, only added to be compatible with other platforms')
-    parser.add_argument('--license-file', nargs='+', help='License filename(s)')
+    parser.add_argument('--trace', default=vrnetlab.bool_from_env('TRACE'), action='store_true', help='enable trace level logging')
+    parser.add_argument('--username', default=os.getenv('USERNAME', 'vrnetlab'), help='Username')
+    parser.add_argument('--password', default=os.getenv('PASSWORD', 'VR-netlab9'), help='Password')
+    parser.add_argument('--install', default=vrnetlab.bool_from_env('INSTALL'), action='store_true', help='Install vMX')
+    parser.add_argument('--dual-re', default=vrnetlab.bool_from_env('DUAL_RE'), action='store_true', help='Boot dual Routing Engines')
+    parser.add_argument('--num-nics', default=int(os.getenv('NUM_NICS', 96)), type=int, help='Number of NICs, this parameter is IGNORED, only added to be compatible with other platforms')
+    parser.add_argument('--license-file', default=vrnetlab.list_from_env('LICENSE_FILE'), nargs='+', help='License filename(s)')
     args = parser.parse_args()
 
     LOG_FORMAT = "%(asctime)s: %(module)-10s %(levelname)-8s %(message)s"

--- a/vqfx/docker/launch.py
+++ b/vqfx/docker/launch.py
@@ -212,10 +212,10 @@ class VQFX(vrnetlab.VR):
 if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser(description='')
-    parser.add_argument('--trace', action='store_true', help='enable trace level logging')
-    parser.add_argument('--username', default='vrnetlab', help='Username')
-    parser.add_argument('--password', default='VR-netlab9', help='Password')
-    parser.add_argument('--install', action='store_true', help='Install vMX')
+    parser.add_argument('--trace', default=vrnetlab.bool_from_env('TRACE'), action='store_true', help='enable trace level logging')
+    parser.add_argument('--username', default=os.getenv('USERNAME', 'vrnetlab'), help='Username')
+    parser.add_argument('--password', default=os.getenv('PASSWORD', 'VR-netlab9'), help='Password')
+    parser.add_argument('--install', default=vrnetlab.bool_from_env('INSTALL'), action='store_true', help='Install vQFX')
     args = parser.parse_args()
 
     LOG_FORMAT = "%(asctime)s: %(module)-10s %(levelname)-8s %(message)s"

--- a/vrp/docker/launch.py
+++ b/vrp/docker/launch.py
@@ -165,10 +165,10 @@ class simulator(vrnetlab.VR):
 if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser(description='')
-    parser.add_argument('--trace', action='store_true', help='enable trace level logging')
-    parser.add_argument('--username', default='vrnetlab', help='Username')
-    parser.add_argument('--password', default='VR-netlab9', help='Password')
-    parser.add_argument('--num-nics', default=14, type=int, help='Number of NICs, this parameter is IGNORED, only added to be compatible with other platforms')
+    parser.add_argument('--trace', default=vrnetlab.bool_from_env('TRACE'), action='store_true', help='enable trace level logging')
+    parser.add_argument('--username', default=os.getenv('USERNAME', 'vrnetlab'), help='Username')
+    parser.add_argument('--password', default=os.getenv('PASSWORD', 'VR-netlab9'), help='Password')
+    parser.add_argument('--num-nics', default=int(os.getenv('NUM_NICS', 14)), type=int, help='Number of NICs, this parameter is IGNORED, only added to be compatible with other platforms')
 
     args = parser.parse_args()
 

--- a/vsr1000/docker/launch.py
+++ b/vsr1000/docker/launch.py
@@ -146,9 +146,9 @@ class VSR(vrnetlab.VR):
 if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser(description='')
-    parser.add_argument('--trace', action='store_true', help='enable trace level logging')
-    parser.add_argument('--username', default='vrnetlab', help='Username')
-    parser.add_argument('--password', default='VR-netlab9', help='Password')
+    parser.add_argument('--trace', default=vrnetlab.bool_from_env('TRACE'), action='store_true', help='enable trace level logging')
+    parser.add_argument('--username', default=os.getenv('USERNAME', 'vrnetlab'), help='Username')
+    parser.add_argument('--password', default=os.getenv('PASSWORD', 'VR-netlab9'), help='Password')
     args = parser.parse_args()
 
     LOG_FORMAT = "%(asctime)s: %(module)-10s %(levelname)-8s %(message)s"

--- a/xrv/docker/launch.py
+++ b/xrv/docker/launch.py
@@ -174,9 +174,9 @@ class XRV(vrnetlab.VR):
 if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser(description='')
-    parser.add_argument('--trace', action='store_true', help='enable trace level logging')
-    parser.add_argument('--username', default='vrnetlab', help='Username')
-    parser.add_argument('--password', default='VR-netlab9', help='Password')
+    parser.add_argument('--trace', default=vrnetlab.bool_from_env('TRACE'), action='store_true', help='enable trace level logging')
+    parser.add_argument('--username', default=os.getenv('USERNAME', 'vrnetlab'), help='Username')
+    parser.add_argument('--password', default=os.getenv('PASSWORD', 'VR-netlab9'), help='Password')
     args = parser.parse_args()
 
     LOG_FORMAT = "%(asctime)s: %(module)-10s %(levelname)-8s %(message)s"

--- a/xrv9k/docker/launch.py
+++ b/xrv9k/docker/launch.py
@@ -218,12 +218,12 @@ class XRV(vrnetlab.VR):
 if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser(description='')
-    parser.add_argument('--trace', action='store_true', help='enable trace level logging')
-    parser.add_argument('--username', default='vrnetlab', help='Username')
-    parser.add_argument('--password', default='VR-netlab9', help='Password')
-    parser.add_argument('--install',  action='store_true', help='Initial install')
-    parser.add_argument('--num-nics', type=int, default=24, help='Number of NICS')
-    parser.add_argument('--ram', type=int, default=16, help='RAM in GB')
+    parser.add_argument('--trace', default=vrnetlab.bool_from_env('TRACE'), action='store_true', help='enable trace level logging')
+    parser.add_argument('--username', default=os.getenv('USERNAME', 'vrnetlab'), help='Username')
+    parser.add_argument('--password', default=os.getenv('PASSWORD', 'VR-netlab9'), help='Password')
+    parser.add_argument('--install', default=vrnetlab.bool_from_env('INSTALL'), action='store_true', help='Initial install')
+    parser.add_argument('--num-nics', type=int, default=int(os.getenv('NUM_NICS', 24)), help='Number of NICS')
+    parser.add_argument('--ram', type=int, default=int(os.getenv('RAM', 16)), help='RAM in GB')
     args = parser.parse_args()
 
     LOG_FORMAT = "%(asctime)s: %(module)-10s %(levelname)-8s %(message)s"


### PR DESCRIPTION
We expose the existing command-line arguments as environment variables to offer an alternative method of configuring the container. This is helpful in combination with containerlab, where containerlab provides a partial list of arguments for username, password, hostname and connection-mode, leaving no option for the user to append to it.